### PR TITLE
Corrections for I2CLcd class

### DIFF
--- a/diozero-core/src/main/java/com/diozero/I2CLcd.java
+++ b/diozero-core/src/main/java/com/diozero/I2CLcd.java
@@ -50,7 +50,7 @@ public class I2CLcd implements Closeable {
 	private static final boolean DEFAULT_BACKLIGHT_STATE = true;
 
 	// I2C device address
-	private static final int DEFAULT_DEVICE_ADDRESS = 0x27;
+	public static final int DEFAULT_DEVICE_ADDRESS = 0x27;
 	
 	/*
 	 * Instructions:
@@ -210,6 +210,10 @@ public class I2CLcd implements Closeable {
 		this(I2CConstants.BUS_1, DEFAULT_DEVICE_ADDRESS, ByteOrder.LITTLE_ENDIAN, columns, rows);
 	}
 
+	public I2CLcd(int deviceAddress, int columns, int rows) {
+		this(I2CConstants.BUS_1, deviceAddress, ByteOrder.LITTLE_ENDIAN, columns, rows);
+	}
+	
 	public I2CLcd(int controller, int deviceAddress, ByteOrder order, int columns, int rows) {
 		if (rows == 2) {
 			rowOffsets = ROW_OFFSETS_2ROWS;
@@ -257,7 +261,7 @@ public class I2CLcd implements Closeable {
 		// Now set it to 4-bit mode
 		write4Bits(true, (byte) (INST_FUNCTION_SET | FS_DATA_LENGTH_4BIT));
 
-		// Function set: 4-bit data length, lines & character font as requested 
+		// Function set: 4-bit data length, lines & character font as requested
 		writeInstruction((byte) (INST_FUNCTION_SET
 				| FS_DATA_LENGTH_4BIT
 				| (rows == 1 ? FS_DISPLAY_1LINE : FS_DISPLAY_2LINES)
@@ -345,7 +349,8 @@ public class I2CLcd implements Closeable {
 		}
 
 		// Trim the string to the length of the column
-		String str = text.substring(0, columns);
+		if (text.length() >= columns)
+			text = text.substring(0, columns);
 		
 		// Set the cursor position to the start of the specified row
 		setCursorPosition(0, row);
@@ -392,7 +397,7 @@ public class I2CLcd implements Closeable {
 	 *				Shifts the entire display either to the right (I/D = 0) or
 	 *				to the left (I/D = 1) when true. The display does not shift
 	 *				if false. If true, it will seem as if the cursor does not
-	 *				move but the display does. 
+	 *				move but the display does.
 	 */
 	public void entryModeControl(boolean increment, boolean shiftDisplay) {
 		this.increment = increment;

--- a/diozero-core/src/main/java/com/diozero/sampleapps/I2CLcdSampleApp20x4.java
+++ b/diozero-core/src/main/java/com/diozero/sampleapps/I2CLcdSampleApp20x4.java
@@ -10,22 +10,26 @@ import com.diozero.util.SleepUtil;
  * I2C LCD sample application. To run:
  * <ul>
  * <li>JDK Device I/O 1.0:<br>
- *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-jdkdio10-$DIOZERO_VERSION.jar:dio-1.0.1-dev-linux-armv6hf.jar -Djava.library.path=. com.diozero.sandpit.I2CLcdSampleApp20x4}</li>
+ *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-jdkdio10-$DIOZERO_VERSION.jar:dio-1.0.1-dev-linux-armv6hf.jar -Djava.library.path=. com.diozero.sandpit.I2CLcdSampleApp20x4 [i2c_address]}</li>
  * <li>JDK Device I/O 1.1:<br>
- *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-jdkdio11-$DIOZERO_VERSION.jar:dio-1.1-dev-linux-armv6hf.jar -Djava.library.path=. com.diozero.sandpit.I2CLcdSampleApp20x4}</li>
+ *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-jdkdio11-$DIOZERO_VERSION.jar:dio-1.1-dev-linux-armv6hf.jar -Djava.library.path=. com.diozero.sandpit.I2CLcdSampleApp20x4 [i2c_address]}</li>
  * <li>Pi4j:<br>
- *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-pi4j-$DIOZERO_VERSION.jar:pi4j-core-1.1-SNAPSHOT.jar com.diozero.sandpit.I2CLcdSampleApp20x4}</li>
+ *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-pi4j-$DIOZERO_VERSION.jar:pi4j-core-1.1-SNAPSHOT.jar com.diozero.sandpit.I2CLcdSampleApp20x4 [i2c_address]}</li>
  * <li>wiringPi:<br>
- *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-wiringpi-$DIOZERO_VERSION.jar:pi4j-core-1.1-SNAPSHOT.jar com.diozero.sandpit.I2CLcdSampleApp20x4}</li>
+ *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-wiringpi-$DIOZERO_VERSION.jar:pi4j-core-1.1-SNAPSHOT.jar com.diozero.sandpit.I2CLcdSampleApp20x4 [i2c_address]}</li>
  * <li>pigpgioJ:<br>
- *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-pigpio-$DIOZERO_VERSION.jar:pigpioj-java-1.0.0.jar com.diozero.sandpit.I2CLcdSampleApp20x4}</li>
+ *  {@code sudo java -cp tinylog-1.0.3.jar:diozero-core-$DIOZERO_VERSION.jar:diozero-provider-pigpio-$DIOZERO_VERSION.jar:pigpioj-java-1.0.0.jar com.diozero.sandpit.I2CLcdSampleApp20x4 [i2c_address]}</li>
  * </ul>
  */
 public class I2CLcdSampleApp20x4 {
 	// Main program block
 	public static void main(String[] args) {
+		int deviceAddress = I2CLcd.DEFAULT_DEVICE_ADDRESS;
+		if (args.length == 1)
+			deviceAddress = Integer.decode(args[0]);
+		
 		// Initialise display
-		try (I2CLcd lcd = new I2CLcd(20, 4)) {
+		try (I2CLcd lcd = new I2CLcd(deviceAddress, 20, 4)) {
 			
 			byte[] space_invader = new byte[] { 0x00, 0x0e, 0x15, 0x1f, 0x0a, 0x04, 0x0a, 0x11 };
 			byte[] smilie = new byte[] { 0x00, 0x00, 0x0a, 0x00, 0x00, 0x11, 0x0e, 0x00 };


### PR DESCRIPTION
- fixed I2CLcd.setText: corrected the trimming, it crashed, if the text was shorter than 20 characters
- added a third constructor, as the displays have varying i2c addresses and user commonly need to specify that
- updated the demo to be able to provide non-default device address on the command line