### PR TITLE
Added ability to set NativeDeviceFactoryInterface from code

### DIFF
--- a/diozero-core/src/main/java/com/diozero/internal/DeviceFactoryHelper.java
+++ b/diozero-core/src/main/java/com/diozero/internal/DeviceFactoryHelper.java
@@ -90,6 +90,14 @@ public class DeviceFactoryHelper {
 		
 		return nativeDeviceFactory;
 	}
+
+	public static void setNativeDeviceFactory(NativeDeviceFactoryInterface f) {
+		synchronized (DeviceFactoryHelper.class) {
+			if (nativeDeviceFactory != null)
+				throw new IllegalStateException("Alreade initialized");
+			nativeDeviceFactory = f;
+		}
+	}
 }
 
 class ShutdownHandlerThread extends Thread {


### PR DESCRIPTION
This is a workaround for remote-vm-launcher, where I can set neither VM parameter nor the MANIFEST.MF is not picked somehow. It might have other use-cases too.