### PR TITLE
fixes to allow local dev builds succeeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -448,19 +448,6 @@
 					<licenseName>mit</licenseName>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -42,17 +42,7 @@
 
 			<!-- Now, select which projects to include in this module-set. -->
 			<includes>
-				<include>com.diozero:diozero-core</include>
-				<include>com.diozero:diozero-provider-jdkdio10</include>
-				<include>com.diozero:diozero-provider-jdkdio11</include>
-				<include>com.diozero:diozero-provider-jpi</include>
-				<include>com.diozero:diozero-provider-pi4j</include>
-				<include>com.diozero:diozero-provider-pigpio</include>
-				<include>com.diozero:diozero-provider-sysfs</include>
-				<include>com.diozero:diozero-provider-wiringpi</include>
-				<include>com.diozero:diozero-ws281x-java</include>
-				<include>com.diozero:diozero-imu-devices</include>
-				<include>com.diozero:diozero-imu-sampleapp</include>
+				<include>com.diozero:diozero-*:*</include>
 			</includes>
 			<binaries>
 				<!-- <outputDirectory>.</outputDirectory> -->


### PR DESCRIPTION
These were the fixes needed to get my local Maven build succeeding.

That is, I was able to build all but module 'diozero-provider-jdkdio11', due to the missing dependency jar 'device-io-1.1.jar' in the distro file 'diozero-distribution-0.8-SNAPSHOT.zip'