### PR TITLE
Do not set all pins on MCP23xxx to zero when initialising

### DIFF
--- a/diozero-core/src/main/java/com/diozero/devices/mcp23xxx/MCP23xxx.java
+++ b/diozero-core/src/main/java/com/diozero/devices/mcp23xxx/MCP23xxx.java
@@ -5,7 +5,7 @@ package com.diozero.devices.mcp23xxx;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     MCP23xxx.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.devices.mcp23xxx;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -203,8 +203,6 @@ public abstract class MCP23xxx extends AbstractDeviceFactory implements GpioDevi
 			writeByte(getIntConReg(port), interruptCompareFlags[port].getValue());
 			// Disable pull-up resistors
 			writeByte(getGPPullUpReg(port), pullUps[port].getValue());
-			// Set all values to off
-			writeByte(getGPIOReg(port), (byte) 0);
 		}
 
 		// Finally enable interrupt listeners


### PR DESCRIPTION
I would like to avoid setting all pins of MCP23xxx on application start. 
It is possible to set pins values to zero if needed, after initialisation. However, when all pins are set to off during initialisation, it may cause some side effects (like lights blinking) on application restart.
In my case, on application restart, lights are turned on (relays) and window shutters get open. I would like to avoid this behaviour by removing this code from initialisation. 

Alternatively, I could prepare a separate constructor for `MCP23017` to let the developer decide if he wants to turn off all pins on initialisation.

What do you think?