### PR TITLE
Adds Thread.onSpinWait to nano sleeps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Board Computers like the Raspberry Pi. Actual GPIO / I<sup>2</sup>C / SPI device
 to pluggable service providers for maximum compatibility across different boards. This library is 
 known to work on the following boards: all models of the Raspberry Pi, Odroid C2, BeagleBone 
 (Green and Black), C.H.I.P and ASUS Tinker Board. It should be portable to any Single Board computer that 
-runs Linux and Java 8.
+runs Linux and Java 11+.
 
 This library makes use of modern Java features such as 
 [automatic resource management](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html), 

--- a/diozero-bom/pom.xml
+++ b/diozero-bom/pom.xml
@@ -59,7 +59,7 @@
 
 		<!-- Java version -->
 		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.release>11</maven.compiler.release>
 
 		<!-- Maven plugins -->
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
@@ -320,7 +320,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 
 		<profile>

--- a/diozero-core/src/main/java/com/diozero/util/SleepUtil.java
+++ b/diozero-core/src/main/java/com/diozero/util/SleepUtil.java
@@ -5,7 +5,7 @@ package com.diozero.util;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     SleepUtil.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.util;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -81,8 +81,8 @@ public class SleepUtil {
 	 * Busy sleep for the specified number of nanoseconds. It is the caller's
 	 * responsibility to factor in any delays associated with calling this method -
 	 * this could be as much as 1.5 microseconds on a Raspberry Pi 4.
-	 *
-	 * Warning - this will consume 100% of one core, use with caution and only with
+	 * <p>
+	 * Warning - this <b>MAY</b> consume 100% of one core: use with caution and only with
 	 * small delays.
 	 *
 	 * @param nanos The period to delay for
@@ -90,8 +90,7 @@ public class SleepUtil {
 	public static void busySleep(final long nanos) {
 		final long start_time = System.nanoTime();
 		do {
-			// nop
-			// In Java 9+ use Thread.onSpinWait()?
+			Thread.onSpinWait();
 		} while ((System.nanoTime() - start_time) < nanos);
 	}
 

--- a/diozero-remote-common/pom.xml
+++ b/diozero-remote-common/pom.xml
@@ -17,6 +17,7 @@
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 		<protoc.version>3.17.2</protoc.version>
 		<motd-os-maven-plugin.version>1.7.0</motd-os-maven-plugin.version>
+		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 	</properties>
 
 	<build>
@@ -80,9 +81,16 @@
 				<artifactId>grpc-stub</artifactId>
 				<version>${grpc.version}</version>
 			</dependency>
+
+			<!-- no longer included in JDK 9+ -->
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>${javax.annotation-api.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>com.diozero</groupId>
@@ -100,6 +108,11 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
All platforms should currently support Java 11, so this change bumps the build target to Java 11. `javax.annotations` was added to the _remote_ sub-project as it is required by the `protobuf` generation and is no longer supplied with the JDK proper.