### PR TITLE
Extract common interfaces (and devices) for LCD devices.

### DIFF
--- a/diozero-bom/pom.xml
+++ b/diozero-bom/pom.xml
@@ -90,6 +90,7 @@
 		<netty.version>4.1.86.Final</netty.version>
 		<grpc.version>1.51.1</grpc.version>
 		<junit.version>5.9.1</junit.version>
+		<mockito.version>4.10.0</mockito.version>
 	</properties>
 
 	<!-- Prepare common library versions -->
@@ -163,6 +164,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -179,6 +185,11 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/diozero-core/src/main/java/com/diozero/devices/HD44780Lcd.java
+++ b/diozero-core/src/main/java/com/diozero/devices/HD44780Lcd.java
@@ -5,7 +5,7 @@ package com.diozero.devices;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     HD44780Lcd.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.devices;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,16 +31,7 @@ package com.diozero.devices;
  * #L%
  */
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.diozero.api.DeviceInterface;
-import com.diozero.api.DigitalOutputDevice;
 import com.diozero.api.RuntimeIOException;
-import com.diozero.devices.mcp23xxx.MCP23xxx;
-import com.diozero.internal.spi.GpioDeviceFactoryInterface;
-import com.diozero.util.BitManipulation;
 import com.diozero.util.SleepUtil;
 
 /**
@@ -61,7 +52,7 @@ import com.diozero.util.SleepUtil;
  * Datasheet</a>.
  * </p>
  */
-public class HD44780Lcd implements DeviceInterface {
+public class HD44780Lcd implements LcdInterface {
 	private static final boolean DEFAULT_BACKLIGHT_STATE = true;
 
 	private static final byte DB0 = (byte) (1 << 0);
@@ -225,16 +216,16 @@ public class HD44780Lcd implements DeviceInterface {
 	// For 16x4 LCDs - special memory map layout
 	private static final byte[] ROW_OFFSETS_16x4 = { 0x00, 0x40, 16, 0x40 + 16 };
 
-	private LcdConnection lcdConnection;
-	private boolean dataInHighNibble;
-	private int registerSelectDataMask;
-	private int dataReadMask;
-	private int enableMask;
-	private int backlightOnMask;
+	private final LcdConnection lcdConnection;
+	private final boolean dataInHighNibble;
+	private final int registerSelectDataMask;
+	private final int dataReadMask;
+	private final int enableMask;
+	private final int backlightOnMask;
 	private boolean backlightEnabled;
-	private int columns;
-	private int rows;
-	private boolean characterFont5x8;
+	private final int columns;
+	private final int rows;
+	private final boolean characterFont5x8;
 	private boolean displayOn;
 	private boolean cursorEnabled;
 	private boolean blinkEnabled;
@@ -276,7 +267,7 @@ public class HD44780Lcd implements DeviceInterface {
 
 		/*
 		 * From p39 (4-bit operation, 8-digit × 1-line display with internal reset):
-		 * 
+		 *
 		 * The program must set all functions prior to the 4-bit operation (Table 12).
 		 * When the power is turned on, 8-bit operation is automatically selected and
 		 * the first write is performed as an 8-bit operation. Since DB0 to DB3 are not
@@ -365,56 +356,10 @@ public class HD44780Lcd implements DeviceInterface {
 	}
 
 	public HD44780Lcd setCursorPosition(int column, int row) {
-		if (column < 0 || column >= columns) {
-			throw new IllegalArgumentException("Invalid column (" + column + "), must be 0.." + (column - 1));
-		}
-
-		if (row < 0 || row >= rows) {
-			throw new IllegalArgumentException("Invalid row (" + row + "), must be 0.." + (rows - 1));
-		}
+		columnCheck(column);
+		rowCheck(row);
 
 		writeInstruction((byte) (INST_SET_DDRAM_ADDR | (column + rowOffsets[row])));
-
-		return this;
-	}
-
-	public HD44780Lcd setCharacter(int column, int row, char character) {
-		setCursorPosition(column, row);
-		writeData((byte) character);
-
-		return this;
-	}
-
-	/**
-	 * Send string to display
-	 *
-	 * @param row  Row number (starts at 0)
-	 * @param text Text to display
-	 * @return This object instance
-	 */
-	public HD44780Lcd setText(int row, String text) {
-		if (row < 0 || row >= rows) {
-			throw new IllegalArgumentException("Invalid row (" + row + "), must be 0.." + (rows - 1));
-		}
-
-		// Trim the string to the length of the column
-		if (text.length() >= columns)
-			text = text.substring(0, columns);
-
-		// Set the cursor position to the start of the specified row
-		setCursorPosition(0, row);
-
-		for (byte b : text.getBytes()) {
-			writeData(b);
-		}
-
-		return this;
-	}
-
-	public HD44780Lcd addText(String text) {
-		for (byte b : text.getBytes()) {
-			writeData(b);
-		}
 
 		return this;
 	}
@@ -431,11 +376,6 @@ public class HD44780Lcd implements DeviceInterface {
 		return this;
 	}
 
-	/**
-	 * Clear the display
-	 *
-	 * @return This object instance
-	 */
 	public HD44780Lcd clear() {
 		writeInstruction(INST_CLEAR_DISPLAY);
 		// Seem to have to wait after clearing the display, encounter strange errors
@@ -445,28 +385,12 @@ public class HD44780Lcd implements DeviceInterface {
 		return this;
 	}
 
-	/**
-	 * Return the cursor to the home position
-	 *
-	 * @return This object instance
-	 */
 	public HD44780Lcd returnHome() {
 		writeInstruction(INST_RETURN_HOME);
 
 		return this;
 	}
 
-	/**
-	 * Control text entry mode.
-	 *
-	 * @param increment    The cursor or blinking moves to the right when
-	 *                     incremented by 1 and to the left when decremented by 1.
-	 * @param shiftDisplay Shifts the entire display either to the right (I/D = 0)
-	 *                     or to the left (I/D = 1) when true. The display does not
-	 *                     shift if false. If true, it will seem as if the cursor
-	 *                     does not move but the display does.
-	 * @return This object instance
-	 */
 	public HD44780Lcd entryModeControl(boolean increment, boolean shiftDisplay) {
 		this.increment = increment;
 		this.shiftDisplay = shiftDisplay;
@@ -477,12 +401,12 @@ public class HD44780Lcd implements DeviceInterface {
 	}
 
 	public HD44780Lcd autoscrollOn() {
-		entryModeControl(true, true);
+		entryModeControl(displayOn, true);
 		return this;
 	}
 
 	public HD44780Lcd autoscrollOff() {
-		entryModeControl(true, false);
+		entryModeControl(displayOn, false);
 		return this;
 	}
 
@@ -517,7 +441,8 @@ public class HD44780Lcd implements DeviceInterface {
 	}
 
 	public HD44780Lcd cursorOff() {
-		return displayControl(displayOn, false, blinkEnabled);
+		// also turns off "blink" as that makes the cursor position still visible if enabled
+		return displayControl(displayOn, false, false);
 	}
 
 	public HD44780Lcd blinkOn() {
@@ -536,19 +461,7 @@ public class HD44780Lcd implements DeviceInterface {
 		return blinkEnabled;
 	}
 
-	/**
-	 * Cursor or display shift shifts the cursor position or display to the right or
-	 * left without writing or reading display data. This function is used to
-	 * correct or search the display. In a 2-line display, the cursor moves to the
-	 * second line when it passes the 40th digit of the first line. Note that the
-	 * first and second line displays will shift at the same time. When the
-	 * displayed data is shifted repeatedly each line moves only horizontally. The
-	 * second line display does not shift into the first line position.
-	 *
-	 * @param displayShift Shift the display if true, the cursor if false.
-	 * @param shiftRight   Shift to the right if true, to the left if false.
-	 * @return This object instance
-	 */
+
 	public HD44780Lcd cursorOrDisplayShift(boolean displayShift, boolean shiftRight) {
 		writeInstruction((byte) (INST_CURSOR_DISPLAY_SHIFT | (displayShift ? CDS_DISPLAY_SHIFT : CDS_CURSOR_MOVE)
 				| (shiftRight ? CDS_SHIFT_RIGHT : CDS_SHIFT_LEFT)));
@@ -583,7 +496,7 @@ public class HD44780Lcd implements DeviceInterface {
 	public HD44780Lcd createChar(int location, byte[] charMap) {
 		/*
 		 * In the character generator RAM, the user can rewrite character patterns by
-		 * program. For 5?8 dots, eight character patterns can be written, and for 5?10
+		 * program. For 5x8 dots, eight character patterns can be written, and for 5x10
 		 * dots, four character patterns can be written.
 		 */
 		if (characterFont5x8) {
@@ -620,578 +533,5 @@ public class HD44780Lcd implements DeviceInterface {
 		backlightEnabled = false;
 		clear();
 		displayControl(false, false, false);
-	}
-
-	public static class Characters {
-		private static final Map<String, byte[]> CHARACTERS = new HashMap<>();
-		static {
-			CHARACTERS.put("0", new byte[] { 0xe, 0x1b, 0x1b, 0x1b, 0x1b, 0x1b, 0xe });
-			CHARACTERS.put("1", new byte[] { 0x2, 0x6, 0xe, 0x6, 0x6, 0x6, 0x6 });
-			CHARACTERS.put("2", new byte[] { 0xe, 0x1b, 0x3, 0x6, 0xc, 0x18, 0x1f });
-			CHARACTERS.put("3", new byte[] { 0xe, 0x1b, 0x3, 0xe, 0x3, 0x1b, 0xe });
-			CHARACTERS.put("4", new byte[] { 0x3, 0x7, 0xf, 0x1b, 0x1f, 0x3, 0x3 });
-			CHARACTERS.put("5", new byte[] { 0x1f, 0x18, 0x1e, 0x3, 0x3, 0x1b, 0xe });
-			CHARACTERS.put("6", new byte[] { 0xe, 0x1b, 0x18, 0x1e, 0x1b, 0x1b, 0xe });
-			CHARACTERS.put("7", new byte[] { 0x1f, 0x3, 0x6, 0xc, 0xc, 0xc, 0xc });
-			CHARACTERS.put("8", new byte[] { 0xe, 0x1b, 0x1b, 0xe, 0x1b, 0x1b, 0xe });
-			CHARACTERS.put("9", new byte[] { 0xe, 0x1b, 0x1b, 0xf, 0x3, 0x1b, 0xe });
-			CHARACTERS.put("10", new byte[] { 0x17, 0x15, 0x15, 0x15, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("11", new byte[] { 0xa, 0xa, 0xa, 0xa, 0xa, 0x0, 0x1f });
-			CHARACTERS.put("12", new byte[] { 0x17, 0x11, 0x17, 0x14, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("13", new byte[] { 0x17, 0x11, 0x13, 0x11, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("14", new byte[] { 0x15, 0x15, 0x17, 0x11, 0x11, 0x0, 0x1f });
-			CHARACTERS.put("15", new byte[] { 0x17, 0x14, 0x17, 0x11, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("16", new byte[] { 0x17, 0x14, 0x17, 0x15, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("17", new byte[] { 0x17, 0x11, 0x12, 0x12, 0x12, 0x0, 0x1f });
-			CHARACTERS.put("18", new byte[] { 0x17, 0x15, 0x17, 0x15, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("19", new byte[] { 0x17, 0x15, 0x17, 0x11, 0x17, 0x0, 0x1f });
-			CHARACTERS.put("circle", new byte[] { 0x0, 0xe, 0x11, 0x11, 0x11, 0xe, 0x0 });
-			CHARACTERS.put("cdot", new byte[] { 0x0, 0xe, 0x11, 0x15, 0x11, 0xe, 0x0 });
-			CHARACTERS.put("donut", new byte[] { 0x0, 0xe, 0x1f, 0x1b, 0x1f, 0xe, 0x0 });
-			CHARACTERS.put("ball", new byte[] { 0x0, 0xe, 0x1f, 0x1f, 0x1f, 0xe, 0x0 });
-			CHARACTERS.put("square", new byte[] { 0x0, 0x1f, 0x11, 0x11, 0x11, 0x1f, 0x0 });
-			CHARACTERS.put("sdot", new byte[] { 0x0, 0x1f, 0x11, 0x15, 0x11, 0x1f, 0x0 });
-			CHARACTERS.put("fbox", new byte[] { 0x0, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x0 });
-			CHARACTERS.put("sbox", new byte[] { 0x0, 0x0, 0xe, 0xa, 0xe, 0x0, 0x0 });
-			CHARACTERS.put("sfbox", new byte[] { 0x0, 0x0, 0xe, 0xe, 0xe, 0x0, 0x0 });
-			CHARACTERS.put("bigpointerright", new byte[] { 0x8, 0xc, 0xa, 0x9, 0xa, 0xc, 0x8 });
-			CHARACTERS.put("bigpointerleft", new byte[] { 0x2, 0x6, 0xa, 0x12, 0xa, 0x6, 0x2 });
-			CHARACTERS.put("arrowright", new byte[] { 0x8, 0xc, 0xa, 0x9, 0xa, 0xc, 0x8 });
-			CHARACTERS.put("arrowleft", new byte[] { 0x2, 0x6, 0xa, 0x12, 0xa, 0x6, 0x2 });
-			CHARACTERS.put("ascprogress1", new byte[] { 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10 });
-			CHARACTERS.put("ascprogress2", new byte[] { 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18 });
-			CHARACTERS.put("ascprogress3", new byte[] { 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c });
-			CHARACTERS.put("ascprogress4", new byte[] { 0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e });
-			CHARACTERS.put("fullprogress", new byte[] { 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f });
-			CHARACTERS.put("descprogress1", new byte[] { 1, 1, 1, 1, 1, 1, 1, 1 });
-			CHARACTERS.put("descprogress2", new byte[] { 3, 3, 3, 3, 3, 3, 3, 3 });
-			CHARACTERS.put("descprogress3", new byte[] { 7, 7, 7, 7, 7, 7, 7, 7 });
-			CHARACTERS.put("descprogress4", new byte[] { 15, 15, 15, 15, 15, 15, 15, 15 });
-			CHARACTERS.put("ascchart1", new byte[] { 31, 0, 0, 0, 0, 0, 0, 0 });
-			CHARACTERS.put("ascchart2", new byte[] { 31, 31, 0, 0, 0, 0, 0, 0 });
-			CHARACTERS.put("ascchart3", new byte[] { 31, 31, 31, 0, 0, 0, 0, 0 });
-			CHARACTERS.put("ascchart4", new byte[] { 31, 31, 31, 31, 0, 0, 0, 0 });
-			CHARACTERS.put("ascchart5", new byte[] { 31, 31, 31, 31, 31, 0, 0, 0 });
-			CHARACTERS.put("ascchart6", new byte[] { 31, 31, 31, 31, 31, 31, 0, 0 });
-			CHARACTERS.put("ascchart7", new byte[] { 31, 31, 31, 31, 31, 31, 31, 0 });
-			CHARACTERS.put("descchart1", new byte[] { 0, 0, 0, 0, 0, 0, 0, 31 });
-			CHARACTERS.put("descchart2", new byte[] { 0, 0, 0, 0, 0, 0, 31, 31 });
-			CHARACTERS.put("descchart3", new byte[] { 0, 0, 0, 0, 0, 31, 31, 31 });
-			CHARACTERS.put("descchart4", new byte[] { 0, 0, 0, 0, 31, 31, 31, 31 });
-			CHARACTERS.put("descchart5", new byte[] { 0, 0, 0, 31, 31, 31, 31, 31 });
-			CHARACTERS.put("descchart6", new byte[] { 0, 0, 31, 31, 31, 31, 31, 31 });
-			CHARACTERS.put("descchart7", new byte[] { 0, 31, 31, 31, 31, 31, 31, 31 });
-			CHARACTERS.put("borderleft1", new byte[] { 1, 1, 1, 1, 1, 1, 1, 1 });
-			CHARACTERS.put("borderleft2", new byte[] { 3, 2, 2, 2, 2, 2, 2, 3 });
-			CHARACTERS.put("borderleft3", new byte[] { 7, 4, 4, 4, 4, 4, 4, 7 });
-			CHARACTERS.put("borderleft4", new byte[] { 15, 8, 8, 8, 8, 8, 8, 15 });
-			CHARACTERS.put("borderleft5", new byte[] { 31, 16, 16, 16, 16, 16, 16, 31 });
-			CHARACTERS.put("bordertopbottom5", new byte[] { 31, 0, 0, 0, 0, 0, 0, 31 });
-			CHARACTERS.put("borderright1", new byte[] { 16, 16, 16, 16, 16, 16, 16, 16 });
-			CHARACTERS.put("borderright2", new byte[] { 24, 8, 8, 8, 8, 8, 8, 24 });
-			CHARACTERS.put("borderright3", new byte[] { 28, 4, 4, 4, 4, 4, 4, 28 });
-			CHARACTERS.put("borderright4", new byte[] { 30, 2, 2, 2, 2, 2, 2, 30 });
-			CHARACTERS.put("borderright5", new byte[] { 31, 1, 1, 1, 1, 1, 1, 31 });
-			CHARACTERS.put("box1", new byte[] { 3, 3, 3, 0, 0, 0, 0 });
-			CHARACTERS.put("box2", new byte[] { 24, 24, 24, 0, 0, 0, 0 });
-			CHARACTERS.put("box3", new byte[] { 27, 27, 27, 0, 0, 0, 0 });
-			CHARACTERS.put("box4", new byte[] { 0, 0, 0, 0, 3, 3, 3 });
-			CHARACTERS.put("box5", new byte[] { 3, 3, 3, 0, 3, 3, 3 });
-			CHARACTERS.put("box6", new byte[] { 24, 24, 24, 0, 3, 3, 3 });
-			CHARACTERS.put("box7", new byte[] { 27, 27, 27, 0, 3, 3, 3 });
-			CHARACTERS.put("box8", new byte[] { 0, 0, 0, 0, 24, 24, 24 });
-			CHARACTERS.put("box9", new byte[] { 3, 3, 3, 0, 24, 24, 24 });
-			CHARACTERS.put("box10", new byte[] { 24, 24, 24, 0, 24, 24, 24 });
-			CHARACTERS.put("box11", new byte[] { 27, 27, 27, 0, 24, 24, 24 });
-			CHARACTERS.put("box12", new byte[] { 0, 0, 0, 0, 27, 27, 27 });
-			CHARACTERS.put("box13", new byte[] { 3, 3, 3, 0, 27, 27, 27 });
-			CHARACTERS.put("box14", new byte[] { 24, 24, 24, 0, 27, 27, 27 });
-			CHARACTERS.put("box15", new byte[] { 27, 27, 27, 0, 27, 27, 27 });
-			CHARACTERS.put("euro", new byte[] { 3, 4, 30, 8, 30, 8, 7 });
-			CHARACTERS.put("cent", new byte[] { 0, 0, 14, 17, 16, 21, 14, 8 });
-			CHARACTERS.put("speaker", new byte[] { 1, 3, 15, 15, 15, 3, 1 });
-			CHARACTERS.put("sound", new byte[] { 8, 16, 0, 24, 0, 16, 8 });
-			CHARACTERS.put("x", new byte[] { 0, 27, 14, 4, 14, 27, 0 });
-			CHARACTERS.put("target", new byte[] { 0, 10, 17, 21, 17, 10, 0 });
-			CHARACTERS.put("pointerright", new byte[] { 0, 8, 12, 14, 12, 8, 0 });
-			CHARACTERS.put("pointerup", new byte[] { 0, 0, 4, 14, 31, 0, 0 });
-			CHARACTERS.put("pointerleft", new byte[] { 0, 2, 6, 14, 6, 2, 0 });
-			CHARACTERS.put("pointerdown", new byte[] { 0, 0, 31, 14, 4, 0, 0 });
-			CHARACTERS.put("arrowne", new byte[] { 0, 15, 3, 5, 9, 16, 0 });
-			CHARACTERS.put("arrownw", new byte[] { 0, 30, 24, 20, 18, 1, 0 });
-			CHARACTERS.put("arrowsw", new byte[] { 0, 1, 18, 20, 24, 30, 0 });
-			CHARACTERS.put("arrowse", new byte[] { 0, 16, 9, 5, 3, 15, 0 });
-			CHARACTERS.put("dice1", new byte[] { 0, 0, 0, 4, 0, 0, 0 });
-			CHARACTERS.put("dice2", new byte[] { 0, 16, 0, 0, 0, 1, 0 });
-			CHARACTERS.put("dice3", new byte[] { 0, 16, 0, 4, 0, 1, 0 });
-			CHARACTERS.put("dice4", new byte[] { 0, 17, 0, 0, 0, 17, 0 });
-			CHARACTERS.put("dice5", new byte[] { 0, 17, 0, 4, 0, 17, 0 });
-			CHARACTERS.put("dice6", new byte[] { 0, 17, 0, 17, 0, 17, 0 });
-			CHARACTERS.put("bell", new byte[] { 4, 14, 14, 14, 31, 0, 4 });
-			CHARACTERS.put("smile", new byte[] { 0, 10, 0, 17, 14, 0, 0 });
-			CHARACTERS.put("note", new byte[] { 2, 3, 2, 14, 30, 12, 0 });
-			CHARACTERS.put("clock", new byte[] { 0, 14, 21, 23, 17, 14, 0 });
-			CHARACTERS.put("heart", new byte[] { 0, 10, 31, 31, 31, 14, 4, 0 });
-			CHARACTERS.put("duck", new byte[] { 0, 12, 29, 15, 15, 6, 0 });
-			CHARACTERS.put("check", new byte[] { 0, 1, 3, 22, 28, 8, 0 });
-			CHARACTERS.put("retarrow", new byte[] { 1, 1, 5, 9, 31, 8, 4 });
-			CHARACTERS.put("runninga", new byte[] { 6, 6, 5, 14, 20, 4, 10, 17 });
-			CHARACTERS.put("runningb", new byte[] { 6, 6, 4, 14, 14, 4, 10, 10 });
-			CHARACTERS.put("space_invader", new byte[] { 0x00, 0x0e, 0x15, 0x1f, 0x0a, 0x04, 0x0a, 0x11 });
-			CHARACTERS.put("smilie", new byte[] { 0x00, 0x00, 0x0a, 0x00, 0x00, 0x11, 0x0e, 0x00 });
-			CHARACTERS.put("frownie", new byte[] { 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x0e, 0x11 });
-		}
-
-		public static byte[] get(String code) {
-			return CHARACTERS.get(code);
-		}
-	}
-
-	/**
-	 * Interface for connecting to LCD displays using 4-bit data mode (D4-D7).
-	 *
-	 * Data is packed into single 1-byte payload - 4-bits contain data, the other 4
-	 * bits control backlight, enable, read/write, and register select flags.
-	 */
-	public interface LcdConnection extends AutoCloseable {
-		void write(byte value);
-
-		/**
-		 * Control whether the data bits are in the first or last 4-bits
-		 *
-		 * @return true if the data bits are in the high nibble (bits 4:7)
-		 */
-		boolean isDataInHighNibble();
-
-		/**
-		 * Identify the bit in the byte payload that refers to the backlight control
-		 * flag 1=on, 0=off.
-		 *
-		 * @return the backlight control bit number
-		 */
-		int getBacklightBit();
-
-		/**
-		 * Identify the bit in the byte payload that refers to the enable flag to start
-		 * read/write.
-		 *
-		 * Falling edge triggered
-		 *
-		 * @return the enable flag bit number
-		 */
-		int getEnableBit();
-
-		/**
-		 * Identify the bit in the byte payload that refers to the read/write flag. Not
-		 * implemented.
-		 *
-		 * R/W=0: Write, R/W=1: Read
-		 *
-		 * @return the read/write flag bit number
-		 */
-		int getDataReadWriteBit();
-
-		/**
-		 * Identify the bit in the byte payload that refers to the register select flag.
-		 *
-		 * RS=0: Command, RS=1: Data
-		 *
-		 * @return the register select flag bit number
-		 */
-		int getRegisterSelectBit();
-
-		@Override
-		void close() throws RuntimeIOException;
-	}
-
-	/**
-	 * For connections via a GPIO expansion board.
-	 */
-	public static abstract class GpioExpansionLcdConnection implements LcdConnection {
-		private final GpioExpander gpioExpander;
-		private final int port;
-		private final boolean dataInHighNibble;
-		private final int registerSelectBit;
-		private final int dataReadWriteBit;
-		private final int enableBit;
-		private final int backlightBit;
-
-		public GpioExpansionLcdConnection(GpioExpander gpioExpander, int port, boolean dataInHighNibble,
-				int registerSelectBit, int dataReadWriteBit, int enableBit, int backlightBit) {
-			// All must be unique, register select and enable must be set
-			if (registerSelectBit == dataReadWriteBit || registerSelectBit == enableBit
-					|| registerSelectBit == backlightBit) {
-				throw new IllegalArgumentException("registerSelectBit (" + registerSelectBit + ") must be unique");
-			}
-			if (dataReadWriteBit == enableBit || dataReadWriteBit == backlightBit) {
-				throw new IllegalArgumentException("dataReadWriteBit (" + dataReadWriteBit + ") must be unique");
-			}
-			if (enableBit == backlightBit) {
-				throw new IllegalArgumentException("enableBit (" + enableBit + ") must be unique");
-			}
-			// The control bits must not clash with the data bits
-			if (dataInHighNibble) {
-				if (registerSelectBit > 3 || dataReadWriteBit > 3 || enableBit > 3 || backlightBit > 3) {
-					throw new IllegalArgumentException("Data bits clash with control bits");
-				}
-			} else {
-				if (registerSelectBit < 4 || dataReadWriteBit < 4 || enableBit < 4 || backlightBit < 4) {
-					throw new IllegalArgumentException("Data bits clash with control bits");
-				}
-			}
-
-			this.gpioExpander = gpioExpander;
-			this.port = port;
-			this.dataInHighNibble = dataInHighNibble;
-			this.registerSelectBit = registerSelectBit;
-			this.dataReadWriteBit = dataReadWriteBit;
-			this.enableBit = enableBit;
-			this.backlightBit = backlightBit;
-
-			gpioExpander.setDirections(port, GpioExpander.ALL_OUTPUT);
-		}
-
-		@Override
-		public void write(byte values) {
-			gpioExpander.setValues(port, values);
-		}
-
-		@Override
-		public boolean isDataInHighNibble() {
-			return dataInHighNibble;
-		}
-
-		@Override
-		public int getRegisterSelectBit() {
-			return registerSelectBit;
-		}
-
-		@Override
-		public int getDataReadWriteBit() {
-			return dataReadWriteBit;
-		}
-
-		@Override
-		public int getEnableBit() {
-			return enableBit;
-		}
-
-		@Override
-		public int getBacklightBit() {
-			return backlightBit;
-		}
-
-		@Override
-		public void close() throws RuntimeIOException {
-			gpioExpander.close();
-		}
-	}
-
-	/**
-	 * Connect via an Output Shift Register.
-	 */
-	public static class OutputShiftRegisterLcdConnection extends GpioExpansionLcdConnection {
-		/**
-		 * Constructor.
-		 *
-		 * @param osr               the output shift register instance
-		 * @param port              the port containing the 8 outputs that are connected
-		 *                          to the LCD
-		 * @param dataInHighNibble  set to true if the d4:d7 of the LCD are connected to
-		 *                          GPIOs 4-7 in the specified port
-		 * @param registerSelectBit the output number in the specified port that is
-		 *                          connected to the RS pin of the LCD
-		 * @param dataReadWriteBit  the output number in the specified port that is
-		 *                          connected to the RW pin of the LCD
-		 * @param enableBit         the output number in the specified port that is
-		 *                          connected to the E pin of the LCD
-		 * @param backlightBit      the output number in the specified port that is
-		 *                          connected to the A pin of the LCD
-		 */
-		public OutputShiftRegisterLcdConnection(OutputShiftRegister osr, int port, boolean dataInHighNibble,
-				int registerSelectBit, int dataReadWriteBit, int enableBit, int backlightBit) {
-			super(osr, port, dataInHighNibble, registerSelectBit, dataReadWriteBit, enableBit, backlightBit);
-		}
-	}
-
-	/**
-	 * MCP23S17 GPIOB to HD44780.
-	 *
-	 * Wiring:
-	 *
-	 * <pre>
-	 * PH_PIN_D4 = 0
-	 * PH_PIN_D5 = 1
-	 * PH_PIN_D6 = 2
-	 * PH_PIN_D7 = 3
-	 * PH_PIN_ENABLE = 4
-	 * PH_PIN_RW = 5
-	 * PH_PIN_RS = 6
-	 * PH_PIN_LED_EN = 7
-	 * </pre>
-	 */
-	public static class PiFaceCadLcdConnection extends GpioExpansionLcdConnection {
-		private static final int CHIP_SELECT = 1;
-		private static final int ADDRESS = 0;
-		private static final int PORT = 1;
-
-		private static final byte REGISTER_SELECT_BIT = 6;
-		private static final byte DATA_READ_WRITE_BIT = 5;
-		private static final byte ENABLE_BIT = 4;
-		private static final int BACKLIGHT_BIT = 7;
-
-		public PiFaceCadLcdConnection(int controller) {
-			super(new MCP23S17(controller, CHIP_SELECT, ADDRESS, MCP23xxx.INTERRUPT_GPIO_NOT_SET), PORT, false,
-					REGISTER_SELECT_BIT, DATA_READ_WRITE_BIT, ENABLE_BIT, BACKLIGHT_BIT);
-		}
-	}
-
-	/**
-	 * Connected via the PCF8574 I2C GPIO expansion backpack.
-	 * 
-	 * Default PCF8574 GPIO to HD44780 pin map:
-	 *
-	 * <pre>
-	 * PH_PIN_RS = 0
-	 * PH_PIN_RW = 1
-	 * PH_PIN_ENABLE = 2
-	 * PH_PIN_LED_EN = 3
-	 * PH_PIN_D4 = 4
-	 * PH_PIN_D5 = 5
-	 * PH_PIN_D6 = 6
-	 * PH_PIN_D7 = 7
-	 * </pre>
-	 */
-	public static class PCF8574LcdConnection extends GpioExpansionLcdConnection {
-		// Default I2C device address for the PCF8574
-		public static final int DEFAULT_DEVICE_ADDRESS = 0x27;
-		// Only one port
-		private static final int PORT = 0;
-
-		private static final boolean DEFAULT_DATA_IN_HIGH_NIBBLE = true;
-		private static final int DEFAULT_REGISTER_SELECT_BIT = 0;
-		private static final int DEFAULT_DATA_READ_WRITE_BIT = 1;
-		private static final int DEFAULT_ENABLE_BIT = 2;
-		private static final int DEFAULT_BACKLIGHT_BIT = 3;
-
-		public PCF8574LcdConnection(int controller) {
-			this(controller, DEFAULT_DEVICE_ADDRESS, DEFAULT_DATA_IN_HIGH_NIBBLE, DEFAULT_REGISTER_SELECT_BIT,
-					DEFAULT_DATA_READ_WRITE_BIT, DEFAULT_ENABLE_BIT, DEFAULT_BACKLIGHT_BIT);
-		}
-
-		public PCF8574LcdConnection(int controller, int deviceAddress) {
-			this(controller, deviceAddress, DEFAULT_DATA_IN_HIGH_NIBBLE, DEFAULT_REGISTER_SELECT_BIT,
-					DEFAULT_DATA_READ_WRITE_BIT, DEFAULT_ENABLE_BIT, DEFAULT_BACKLIGHT_BIT);
-		}
-
-		public PCF8574LcdConnection(int controller, int deviceAddress, boolean dataInHighNibble, int registerSelectBit,
-				int dataReadWriteBit, int enableBit, int backlightBit) {
-			super(new PCF8574(controller, deviceAddress), PORT, dataInHighNibble, registerSelectBit, dataReadWriteBit,
-					enableBit, backlightBit);
-		}
-	}
-
-	/**
-	 * Connect via individual GPIO pins, uses 4-bit mode (data pins D4-D7).
-	 *
-	 * Wiring (from left-to-right):
-	 *
-	 * <pre>
-	 * Vss: GND
-	 * Vdd: 5v
-	 * V0: Contrast adjustment (connect to Vdd for full brightness)
-	 * RS: Register Select - GPIO
-	 * RW: Data read/write (not required, read mode not used - can connect to GND)
-	 * E: Enable - GPIO
-	 * D0-D3: Don't connect (currently only 4-bit mode is supported)
-	 * D4-D7: Data pins - GPIO
-	 * A: Backlight LED Cathode (+) - GPIO (need to check 3v3/5v) or Vdd (always on)
-	 * K: Backlight LED Anode (-) - GND
-	 * </pre>
-	 */
-	public static class GpioLcdConnection implements LcdConnection {
-		private static final int DATA_RW_BIT = 4;
-		private static final int REGISTER_SELECT_BIT = 5;
-		private static final int ENABLE_BIT = 6;
-		private static final int BACKLIGHT_BIT = 7;
-
-		private final DigitalOutputDevice[] dataPins;
-		private final DigitalOutputDevice registerSelectPin;
-		private final DigitalOutputDevice dataRwPin;
-		private final DigitalOutputDevice enablePin;
-		private final DigitalOutputDevice backlightPin;
-
-		/**
-		 * Use the default device factory and specify GPIO numbers. Assumes the RW pin
-		 * is pulled low and the backlight pin pulled high.
-		 *
-		 * @param d4                 GPIO number for d4 pin
-		 * @param d5                 GPIO number for d5 pin
-		 * @param d6                 GPIO number for d6 pin
-		 * @param d7                 GPIO number for d7 pin
-		 * @param enableGpio         enable GPIO number
-		 * @param registerSelectGpio register select GPIO number
-		 */
-		public GpioLcdConnection(int d4, int d5, int d6, int d7, int enableGpio, int registerSelectGpio) {
-			this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
-					new DigitalOutputDevice(d7), null, new DigitalOutputDevice(enableGpio), null,
-					new DigitalOutputDevice(registerSelectGpio));
-		}
-
-		/**
-		 * Use the default device factory and specify GPIO numbers. Assumes the RW pin
-		 * is pulled low.
-		 *
-		 * @param d4                 GPIO number for d4 pin
-		 * @param d5                 GPIO number for d5 pin
-		 * @param d6                 GPIO number for d6 pin
-		 * @param d7                 GPIO number for d7 pin
-		 * @param backlightGpio      backlight control GPIO number (set to -1 if not
-		 *                           connected)
-		 * @param enableGpio         enable GPIO number
-		 * @param registerSelectGpio register select GPIO number
-		 */
-		public GpioLcdConnection(int d4, int d5, int d6, int d7, int backlightGpio, int enableGpio,
-				int registerSelectGpio) {
-			this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
-					new DigitalOutputDevice(d7), backlightGpio == -1 ? null : new DigitalOutputDevice(backlightGpio),
-					new DigitalOutputDevice(enableGpio), null, new DigitalOutputDevice(registerSelectGpio));
-		}
-
-		/**
-		 * Use the default device factory and specify GPIO numbers.
-		 *
-		 * @param d4                 GPIO number for d4 pin
-		 * @param d5                 GPIO number for d5 pin
-		 * @param d6                 GPIO number for d6 pin
-		 * @param d7                 GPIO number for d7 pin
-		 * @param backlightGpio      backlight control GPIO number (set to -1 if not
-		 *                           connected)
-		 * @param enableGpio         enable GPIO number
-		 * @param dataRwGpio         data read/write GPIO number (not used - connect to
-		 *                           GND, set to -1 if not connected)
-		 * @param registerSelectGpio register select GPIO number
-		 */
-		public GpioLcdConnection(int d4, int d5, int d6, int d7, int backlightGpio, int enableGpio, int dataRwGpio,
-				int registerSelectGpio) {
-			this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
-					new DigitalOutputDevice(d7), backlightGpio == -1 ? null : new DigitalOutputDevice(backlightGpio),
-					new DigitalOutputDevice(enableGpio), dataRwGpio == -1 ? null : new DigitalOutputDevice(dataRwGpio),
-					new DigitalOutputDevice(registerSelectGpio));
-		}
-
-		/**
-		 * Use the specified device factory and specify GPIO numbers.
-		 *
-		 * @param deviceFactory      the device factory to use for provisioning the
-		 *                           GPIOs
-		 * @param d4                 GPIO number for d4 pin
-		 * @param d5                 GPIO number for d5 pin
-		 * @param d6                 GPIO number for d6 pin
-		 * @param d7                 GPIO number for d7 pin
-		 * @param backlightGpio      backlight control GPIO number (set to -1 if not
-		 *                           connected)
-		 * @param enableGpio         enable GPIO number
-		 * @param dataRwGpio         data read/write GPIO number (not used - connect to
-		 *                           GND, set to -1 if not connected)
-		 * @param registerSelectGpio register select GPIO number
-		 */
-		public GpioLcdConnection(GpioDeviceFactoryInterface deviceFactory, int d4, int d5, int d6, int d7,
-				int backlightGpio, int enableGpio, int dataRwGpio, int registerSelectGpio) {
-			this(DigitalOutputDevice.Builder.builder(d4).setDeviceFactory(deviceFactory).build(),
-					DigitalOutputDevice.Builder.builder(d5).setDeviceFactory(deviceFactory).build(),
-					DigitalOutputDevice.Builder.builder(d6).setDeviceFactory(deviceFactory).build(),
-					DigitalOutputDevice.Builder.builder(d7).setDeviceFactory(deviceFactory).build(),
-					backlightGpio == -1 ? null
-							: DigitalOutputDevice.Builder.builder(backlightGpio).setDeviceFactory(deviceFactory)
-									.build(),
-					DigitalOutputDevice.Builder.builder(enableGpio).setDeviceFactory(deviceFactory).build(),
-					dataRwGpio == -1 ? null
-							: DigitalOutputDevice.Builder.builder(dataRwGpio).setDeviceFactory(deviceFactory).build(),
-					DigitalOutputDevice.Builder.builder(registerSelectGpio).setDeviceFactory(deviceFactory).build());
-		}
-
-		/**
-		 * Use the specified digital output devices.
-		 *
-		 * @param d4                Digital output device for d4 pin
-		 * @param d5                Digital output device for d5 pin
-		 * @param d6                Digital output device for d6 pin
-		 * @param d7                Digital output device for d7 pin
-		 * @param backlightPin      backlight control digital output device (set to null
-		 *                          if not connected)
-		 * @param enablePin         enable digital output device
-		 * @param dataRwPin         data read/write digital output device (not used -
-		 *                          connect to GND, set to null if not connected)
-		 * @param registerSelectPin register select digital output device
-		 */
-		public GpioLcdConnection(DigitalOutputDevice d4, DigitalOutputDevice d5, DigitalOutputDevice d6,
-				DigitalOutputDevice d7, DigitalOutputDevice backlightPin, DigitalOutputDevice enablePin,
-				DigitalOutputDevice dataRwPin, DigitalOutputDevice registerSelectPin) {
-			dataPins = new DigitalOutputDevice[4];
-			dataPins[0] = d4;
-			dataPins[1] = d5;
-			dataPins[2] = d6;
-			dataPins[3] = d7;
-
-			this.backlightPin = backlightPin;
-			this.enablePin = enablePin;
-			this.dataRwPin = dataRwPin;
-			this.registerSelectPin = registerSelectPin;
-		}
-
-		@Override
-		public void write(byte values) {
-			if (backlightPin != null) {
-				backlightPin.setValue(BitManipulation.isBitSet(values, BACKLIGHT_BIT));
-			}
-			enablePin.setValue(BitManipulation.isBitSet(values, ENABLE_BIT));
-			if (dataRwPin != null) {
-				dataRwPin.setValue(BitManipulation.isBitSet(values, DATA_RW_BIT));
-			}
-			registerSelectPin.setValue(BitManipulation.isBitSet(values, REGISTER_SELECT_BIT));
-
-			for (int i = 0; i < dataPins.length; i++) {
-				dataPins[i].setValue(BitManipulation.isBitSet(values, i));
-			}
-		}
-
-		@Override
-		public boolean isDataInHighNibble() {
-			return false;
-		}
-
-		@Override
-		public int getRegisterSelectBit() {
-			return REGISTER_SELECT_BIT;
-		}
-
-		@Override
-		public int getDataReadWriteBit() {
-			return DATA_RW_BIT;
-		}
-
-		@Override
-		public int getEnableBit() {
-			return ENABLE_BIT;
-		}
-
-		@Override
-		public int getBacklightBit() {
-			return BACKLIGHT_BIT;
-		}
-
-		@Override
-		public void close() throws RuntimeIOException {
-			Arrays.asList(dataPins).forEach(DeviceInterface::close);
-			if (backlightPin != null) {
-				backlightPin.close();
-			}
-			enablePin.close();
-			if (dataRwPin != null) {
-				dataRwPin.close();
-			}
-			registerSelectPin.close();
-		}
 	}
 }

--- a/diozero-core/src/main/java/com/diozero/devices/LcdConnection.java
+++ b/diozero-core/src/main/java/com/diozero/devices/LcdConnection.java
@@ -1,0 +1,459 @@
+package com.diozero.devices;
+
+import java.util.Arrays;
+
+import com.diozero.api.DeviceInterface;
+import com.diozero.api.DigitalOutputDevice;
+import com.diozero.api.RuntimeIOException;
+import com.diozero.devices.mcp23xxx.MCP23xxx;
+import com.diozero.internal.spi.GpioDeviceFactoryInterface;
+import com.diozero.util.BitManipulation;
+
+/**
+ * Interface for connecting to LCD displays using 4-bit data mode (D4-D7).
+ * <p>
+ * Data is packed into single 1-byte payload - 4-bits contain data, the other 4
+ * bits control backlight, enable, read/write, and register select flags.
+ */
+public interface LcdConnection extends AutoCloseable {
+    void write(byte value);
+
+    /**
+     * Control whether the data bits are in the first or last 4-bits
+     *
+     * @return true if the data bits are in the high nibble (bits 4:7)
+     */
+    boolean isDataInHighNibble();
+
+    /**
+     * Identify the bit in the byte payload that refers to the backlight control
+     * flag 1=on, 0=off.
+     *
+     * @return the backlight control bit number
+     */
+    int getBacklightBit();
+
+    /**
+     * Identify the bit in the byte payload that refers to the enable flag to start
+     * read/write.
+     * <p>
+     * Falling edge triggered
+     *
+     * @return the enable flag bit number
+     */
+    int getEnableBit();
+
+    /**
+     * Identify the bit in the byte payload that refers to the read/write flag. Not
+     * implemented.
+     * <p>
+     * R/W=0: Write, R/W=1: Read
+     *
+     * @return the read/write flag bit number
+     */
+    int getDataReadWriteBit();
+
+    /**
+     * Identify the bit in the byte payload that refers to the register select flag.
+     * <p>
+     * RS=0: Command, RS=1: Data
+     *
+     * @return the register select flag bit number
+     */
+    int getRegisterSelectBit();
+
+    @Override
+    void close() throws RuntimeIOException;
+
+    /**
+     * For connections via a GPIO expansion board.
+     */
+    public static abstract class GpioExpansionLcdConnection implements LcdConnection {
+        private final GpioExpander gpioExpander;
+        private final int port;
+        private final boolean dataInHighNibble;
+        private final int registerSelectBit;
+        private final int dataReadWriteBit;
+        private final int enableBit;
+        private final int backlightBit;
+
+        public GpioExpansionLcdConnection(GpioExpander gpioExpander, int port, boolean dataInHighNibble,
+                                          int registerSelectBit, int dataReadWriteBit, int enableBit, int backlightBit) {
+            // All must be unique, register select and enable must be set
+            if (registerSelectBit == dataReadWriteBit || registerSelectBit == enableBit
+                || registerSelectBit == backlightBit) {
+                throw new IllegalArgumentException("registerSelectBit (" + registerSelectBit + ") must be unique");
+            }
+            if (dataReadWriteBit == enableBit || dataReadWriteBit == backlightBit) {
+                throw new IllegalArgumentException("dataReadWriteBit (" + dataReadWriteBit + ") must be unique");
+            }
+            if (enableBit == backlightBit) {
+                throw new IllegalArgumentException("enableBit (" + enableBit + ") must be unique");
+            }
+            // The control bits must not clash with the data bits
+            if (dataInHighNibble) {
+                if (registerSelectBit > 3 || dataReadWriteBit > 3 || enableBit > 3 || backlightBit > 3) {
+                    throw new IllegalArgumentException("Data bits clash with control bits");
+                }
+            } else {
+                if (registerSelectBit < 4 || dataReadWriteBit < 4 || enableBit < 4 || backlightBit < 4) {
+                    throw new IllegalArgumentException("Data bits clash with control bits");
+                }
+            }
+
+            this.gpioExpander = gpioExpander;
+            this.port = port;
+            this.dataInHighNibble = dataInHighNibble;
+            this.registerSelectBit = registerSelectBit;
+            this.dataReadWriteBit = dataReadWriteBit;
+            this.enableBit = enableBit;
+            this.backlightBit = backlightBit;
+
+            gpioExpander.setDirections(port, GpioExpander.ALL_OUTPUT);
+        }
+
+        @Override
+        public void write(byte values) {
+            gpioExpander.setValues(port, values);
+        }
+
+        @Override
+        public boolean isDataInHighNibble() {
+            return dataInHighNibble;
+        }
+
+        @Override
+        public int getRegisterSelectBit() {
+            return registerSelectBit;
+        }
+
+        @Override
+        public int getDataReadWriteBit() {
+            return dataReadWriteBit;
+        }
+
+        @Override
+        public int getEnableBit() {
+            return enableBit;
+        }
+
+        @Override
+        public int getBacklightBit() {
+            return backlightBit;
+        }
+
+        @Override
+        public void close() throws RuntimeIOException {
+            gpioExpander.close();
+        }
+    }
+
+    /**
+     * Connect via an Output Shift Register.
+     */
+    @Deprecated(since="1.3.5")
+    public static class OutputShiftRegisterLcdConnection extends GpioExpansionLcdConnection {
+        /**
+         * Constructor.
+         *
+         * @param osr               the output shift register instance
+         * @param port              the port containing the 8 outputs that are connected
+         *                          to the LCD
+         * @param dataInHighNibble  set to true if the d4:d7 of the LCD are connected to
+         *                          GPIOs 4-7 in the specified port
+         * @param registerSelectBit the output number in the specified port that is
+         *                          connected to the RS pin of the LCD
+         * @param dataReadWriteBit  the output number in the specified port that is
+         *                          connected to the RW pin of the LCD
+         * @param enableBit         the output number in the specified port that is
+         *                          connected to the E pin of the LCD
+         * @param backlightBit      the output number in the specified port that is
+         *                          connected to the A pin of the LCD
+         */
+        public OutputShiftRegisterLcdConnection(OutputShiftRegister osr, int port, boolean dataInHighNibble,
+                                                int registerSelectBit, int dataReadWriteBit, int enableBit, int backlightBit) {
+            super(osr, port, dataInHighNibble, registerSelectBit, dataReadWriteBit, enableBit, backlightBit);
+        }
+    }
+
+    /**
+     * MCP23S17 GPIOB to HD44780.
+     *
+     * Wiring:
+     *
+     * <pre>
+     * PH_PIN_D4 = 0
+     * PH_PIN_D5 = 1
+     * PH_PIN_D6 = 2
+     * PH_PIN_D7 = 3
+     * PH_PIN_ENABLE = 4
+     * PH_PIN_RW = 5
+     * PH_PIN_RS = 6
+     * PH_PIN_LED_EN = 7
+     * </pre>
+     */
+    public static class PiFaceCadLcdConnection extends GpioExpansionLcdConnection {
+        private static final int CHIP_SELECT = 1;
+        private static final int ADDRESS = 0;
+        private static final int PORT = 1;
+
+        private static final byte REGISTER_SELECT_BIT = 6;
+        private static final byte DATA_READ_WRITE_BIT = 5;
+        private static final byte ENABLE_BIT = 4;
+        private static final int BACKLIGHT_BIT = 7;
+
+        public PiFaceCadLcdConnection(int controller) {
+            super(new MCP23S17(controller, CHIP_SELECT, ADDRESS, MCP23xxx.INTERRUPT_GPIO_NOT_SET), PORT, false,
+                  REGISTER_SELECT_BIT, DATA_READ_WRITE_BIT, ENABLE_BIT, BACKLIGHT_BIT);
+        }
+    }
+
+    /**
+     * Connected via the PCF8574 I2C GPIO expansion backpack.
+     *
+     * Default PCF8574 GPIO to HD44780 pin map:
+     *
+     * <pre>
+     * PH_PIN_RS = 0
+     * PH_PIN_RW = 1
+     * PH_PIN_ENABLE = 2
+     * PH_PIN_LED_EN = 3
+     * PH_PIN_D4 = 4
+     * PH_PIN_D5 = 5
+     * PH_PIN_D6 = 6
+     * PH_PIN_D7 = 7
+     * </pre>
+     */
+    public static class PCF8574LcdConnection extends GpioExpansionLcdConnection {
+        // Default I2C device address for the PCF8574
+        public static final int DEFAULT_DEVICE_ADDRESS = 0x27;
+        // Only one port
+        private static final int PORT = 0;
+
+        private static final boolean DEFAULT_DATA_IN_HIGH_NIBBLE = true;
+        private static final int DEFAULT_REGISTER_SELECT_BIT = 0;
+        private static final int DEFAULT_DATA_READ_WRITE_BIT = 1;
+        private static final int DEFAULT_ENABLE_BIT = 2;
+        private static final int DEFAULT_BACKLIGHT_BIT = 3;
+
+        public PCF8574LcdConnection(int controller) {
+            this(controller, DEFAULT_DEVICE_ADDRESS, DEFAULT_DATA_IN_HIGH_NIBBLE, DEFAULT_REGISTER_SELECT_BIT,
+                 DEFAULT_DATA_READ_WRITE_BIT, DEFAULT_ENABLE_BIT, DEFAULT_BACKLIGHT_BIT);
+        }
+
+        public PCF8574LcdConnection(int controller, int deviceAddress) {
+            this(controller, deviceAddress, DEFAULT_DATA_IN_HIGH_NIBBLE, DEFAULT_REGISTER_SELECT_BIT,
+                 DEFAULT_DATA_READ_WRITE_BIT, DEFAULT_ENABLE_BIT, DEFAULT_BACKLIGHT_BIT);
+        }
+
+        public PCF8574LcdConnection(int controller, int deviceAddress, boolean dataInHighNibble, int registerSelectBit,
+                                    int dataReadWriteBit, int enableBit, int backlightBit) {
+            super(new PCF8574(controller, deviceAddress), PORT, dataInHighNibble, registerSelectBit, dataReadWriteBit,
+                  enableBit, backlightBit);
+        }
+    }
+
+    /**
+     * Connect via individual GPIO pins, uses 4-bit mode (data pins D4-D7).
+     *
+     * Wiring (from left-to-right):
+     *
+     * <pre>
+     * Vss: GND
+     * Vdd: 5v
+     * V0: Contrast adjustment (connect to Vdd for full brightness)
+     * RS: Register Select - GPIO
+     * RW: Data read/write (not required, read mode not used - can connect to GND)
+     * E: Enable - GPIO
+     * D0-D3: Don't connect (currently only 4-bit mode is supported)
+     * D4-D7: Data pins - GPIO
+     * A: Backlight LED Cathode (+) - GPIO (need to check 3v3/5v) or Vdd (always on)
+     * K: Backlight LED Anode (-) - GND
+     * </pre>
+     */
+    public static class GpioLcdConnection implements LcdConnection {
+        private static final int DATA_RW_BIT = 4;
+        private static final int REGISTER_SELECT_BIT = 5;
+        private static final int ENABLE_BIT = 6;
+        private static final int BACKLIGHT_BIT = 7;
+
+        private final DigitalOutputDevice[] dataPins;
+        private final DigitalOutputDevice registerSelectPin;
+        private final DigitalOutputDevice dataRwPin;
+        private final DigitalOutputDevice enablePin;
+        private final DigitalOutputDevice backlightPin;
+
+        /**
+         * Use the default device factory and specify GPIO numbers. Assumes the RW pin
+         * is pulled low and the backlight pin pulled high.
+         *
+         * @param d4                 GPIO number for d4 pin
+         * @param d5                 GPIO number for d5 pin
+         * @param d6                 GPIO number for d6 pin
+         * @param d7                 GPIO number for d7 pin
+         * @param enableGpio         enable GPIO number
+         * @param registerSelectGpio register select GPIO number
+         */
+        public GpioLcdConnection(int d4, int d5, int d6, int d7, int enableGpio, int registerSelectGpio) {
+            this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
+                 new DigitalOutputDevice(d7), null, new DigitalOutputDevice(enableGpio), null,
+                 new DigitalOutputDevice(registerSelectGpio));
+        }
+
+        /**
+         * Use the default device factory and specify GPIO numbers. Assumes the RW pin
+         * is pulled low.
+         *
+         * @param d4                 GPIO number for d4 pin
+         * @param d5                 GPIO number for d5 pin
+         * @param d6                 GPIO number for d6 pin
+         * @param d7                 GPIO number for d7 pin
+         * @param backlightGpio      backlight control GPIO number (set to -1 if not
+         *                           connected)
+         * @param enableGpio         enable GPIO number
+         * @param registerSelectGpio register select GPIO number
+         */
+        public GpioLcdConnection(int d4, int d5, int d6, int d7, int backlightGpio, int enableGpio,
+                                 int registerSelectGpio) {
+            this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
+                 new DigitalOutputDevice(d7), backlightGpio == -1 ? null : new DigitalOutputDevice(backlightGpio),
+                 new DigitalOutputDevice(enableGpio), null, new DigitalOutputDevice(registerSelectGpio));
+        }
+
+        /**
+         * Use the default device factory and specify GPIO numbers.
+         *
+         * @param d4                 GPIO number for d4 pin
+         * @param d5                 GPIO number for d5 pin
+         * @param d6                 GPIO number for d6 pin
+         * @param d7                 GPIO number for d7 pin
+         * @param backlightGpio      backlight control GPIO number (set to -1 if not
+         *                           connected)
+         * @param enableGpio         enable GPIO number
+         * @param dataRwGpio         data read/write GPIO number (not used - connect to
+         *                           GND, set to -1 if not connected)
+         * @param registerSelectGpio register select GPIO number
+         */
+        public GpioLcdConnection(int d4, int d5, int d6, int d7, int backlightGpio, int enableGpio, int dataRwGpio,
+                                 int registerSelectGpio) {
+            this(new DigitalOutputDevice(d4), new DigitalOutputDevice(d5), new DigitalOutputDevice(d6),
+                 new DigitalOutputDevice(d7), backlightGpio == -1 ? null : new DigitalOutputDevice(backlightGpio),
+                 new DigitalOutputDevice(enableGpio), dataRwGpio == -1 ? null : new DigitalOutputDevice(dataRwGpio),
+                 new DigitalOutputDevice(registerSelectGpio));
+        }
+
+        /**
+         * Use the specified device factory and specify GPIO numbers.
+         *
+         * @param deviceFactory      the device factory to use for provisioning the
+         *                           GPIOs
+         * @param d4                 GPIO number for d4 pin
+         * @param d5                 GPIO number for d5 pin
+         * @param d6                 GPIO number for d6 pin
+         * @param d7                 GPIO number for d7 pin
+         * @param backlightGpio      backlight control GPIO number (set to -1 if not
+         *                           connected)
+         * @param enableGpio         enable GPIO number
+         * @param dataRwGpio         data read/write GPIO number (not used - connect to
+         *                           GND, set to -1 if not connected)
+         * @param registerSelectGpio register select GPIO number
+         */
+        public GpioLcdConnection(GpioDeviceFactoryInterface deviceFactory, int d4, int d5, int d6, int d7,
+                                 int backlightGpio, int enableGpio, int dataRwGpio, int registerSelectGpio) {
+            this(DigitalOutputDevice.Builder.builder(d4).setDeviceFactory(deviceFactory).build(),
+                 DigitalOutputDevice.Builder.builder(d5).setDeviceFactory(deviceFactory).build(),
+                 DigitalOutputDevice.Builder.builder(d6).setDeviceFactory(deviceFactory).build(),
+                 DigitalOutputDevice.Builder.builder(d7).setDeviceFactory(deviceFactory).build(),
+                 backlightGpio == -1 ? null
+                                     : DigitalOutputDevice.Builder.builder(backlightGpio).setDeviceFactory(deviceFactory)
+                         .build(),
+                 DigitalOutputDevice.Builder.builder(enableGpio).setDeviceFactory(deviceFactory).build(),
+                 dataRwGpio == -1 ? null
+                                  : DigitalOutputDevice.Builder.builder(dataRwGpio).setDeviceFactory(deviceFactory).build(),
+                 DigitalOutputDevice.Builder.builder(registerSelectGpio).setDeviceFactory(deviceFactory).build());
+        }
+
+        /**
+         * Use the specified digital output devices.
+         *
+         * @param d4                Digital output device for d4 pin
+         * @param d5                Digital output device for d5 pin
+         * @param d6                Digital output device for d6 pin
+         * @param d7                Digital output device for d7 pin
+         * @param backlightPin      backlight control digital output device (set to null
+         *                          if not connected)
+         * @param enablePin         enable digital output device
+         * @param dataRwPin         data read/write digital output device (not used -
+         *                          connect to GND, set to null if not connected)
+         * @param registerSelectPin register select digital output device
+         */
+        public GpioLcdConnection(DigitalOutputDevice d4, DigitalOutputDevice d5, DigitalOutputDevice d6,
+                                 DigitalOutputDevice d7, DigitalOutputDevice backlightPin, DigitalOutputDevice enablePin,
+                                 DigitalOutputDevice dataRwPin, DigitalOutputDevice registerSelectPin) {
+            dataPins = new DigitalOutputDevice[4];
+            dataPins[0] = d4;
+            dataPins[1] = d5;
+            dataPins[2] = d6;
+            dataPins[3] = d7;
+
+            this.backlightPin = backlightPin;
+            this.enablePin = enablePin;
+            this.dataRwPin = dataRwPin;
+            this.registerSelectPin = registerSelectPin;
+        }
+
+        @Override
+        public void write(byte values) {
+            if (backlightPin != null) {
+                backlightPin.setValue(BitManipulation.isBitSet(values, BACKLIGHT_BIT));
+            }
+            enablePin.setValue(BitManipulation.isBitSet(values, ENABLE_BIT));
+            if (dataRwPin != null) {
+                dataRwPin.setValue(BitManipulation.isBitSet(values, DATA_RW_BIT));
+            }
+            registerSelectPin.setValue(BitManipulation.isBitSet(values, REGISTER_SELECT_BIT));
+
+            for (int i = 0; i < dataPins.length; i++) {
+                dataPins[i].setValue(BitManipulation.isBitSet(values, i));
+            }
+        }
+
+        @Override
+        public boolean isDataInHighNibble() {
+            return false;
+        }
+
+        @Override
+        public int getRegisterSelectBit() {
+            return REGISTER_SELECT_BIT;
+        }
+
+        @Override
+        public int getDataReadWriteBit() {
+            return DATA_RW_BIT;
+        }
+
+        @Override
+        public int getEnableBit() {
+            return ENABLE_BIT;
+        }
+
+        @Override
+        public int getBacklightBit() {
+            return BACKLIGHT_BIT;
+        }
+
+        @Override
+        public void close() throws RuntimeIOException {
+            Arrays.asList(dataPins).forEach(DeviceInterface::close);
+            if (backlightPin != null) {
+                backlightPin.close();
+            }
+            enablePin.close();
+            if (dataRwPin != null) {
+                dataRwPin.close();
+            }
+            registerSelectPin.close();
+        }
+    }
+}

--- a/diozero-core/src/main/java/com/diozero/devices/LcdInterface.java
+++ b/diozero-core/src/main/java/com/diozero/devices/LcdInterface.java
@@ -1,0 +1,384 @@
+package com.diozero.devices;
+
+/*-
+ * #%L
+ * Organisation: diozero
+ * Project:      diozero - Core
+ * Filename:     LcdInterface.java
+ *
+ * This file is part of the diozero project. More information about this project
+ * can be found at https://www.diozero.com/.
+ * %%
+ * Copyright (C) 2016 - 2022 diozero
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.diozero.api.DeviceInterface;
+import com.diozero.util.StringUtil;
+
+/**
+ * Abstraction for LCD devices: provides common functionality that can be "chained" together
+ * to provide a fluent-style interface.
+ */
+public interface LcdInterface<L extends LcdInterface<?>> extends DeviceInterface {
+    int getColumnCount();
+
+    /**
+     * Checks to see if the requested column is out of range.
+     *
+     * @param column the column
+     */
+    default void columnCheck(int column) {
+        if (column < 0 || column >= getColumnCount()) {
+            throw new IllegalArgumentException("Invalid column (" + column + "), must be 0.." + (getColumnCount() - 1));
+        }
+    }
+
+    int getRowCount();
+
+    /**
+     * Checks to see if the requested row is out of bounds.
+     *
+     * @param row the row
+     */
+    default void rowCheck(int row) {
+        if (row < 0 || row >= getRowCount()) {
+            throw new IllegalArgumentException("Invalid row (" + row + "), must be 0.." + (getRowCount() - 1));
+        }
+    }
+
+    boolean isBacklightEnabled();
+
+    L setBacklightEnabled(boolean backlightEnabled);
+
+    L setCursorPosition(int column, int row);
+
+    /**
+     * Sets a character on the display at a specific location.
+     * @param column the column
+     * @param row the row
+     * @param character the character
+     * @return this
+     */
+    default L setCharacter(int column, int row, char character) {
+        setCursorPosition(column, row);
+        return addText(character);
+    }
+
+    /**
+     * Writes the text to the display, starting at the home position. Newlines ({@code '\n'})
+     * will wrap text to the next line. Excessive characters and lines are <b>trimmed</b>.
+     * Shorter lines are <i>padded</i> to fill the display.
+     *
+     * @param text Text to display
+     * @return this
+     */
+    default L displayText(String text) {
+        String[] splitText = text.split("\n");
+        int minRows = Math.min(getRowCount(), splitText.length);
+        for (int i = 0; i < minRows; i++) {
+            setText(i, StringUtil.pad(splitText[i], getColumnCount()));
+        }
+        return (L)this;
+    }
+
+    /**
+     * Send string to display, truncated to fit.
+     *
+     * @param row  Row number (starts at 0)
+     * @param text Text to display
+     * @return this
+     */
+    default L setText(int row, String text) {
+        rowCheck(row);
+
+        int columns = getColumnCount();
+        int l = text.length();
+
+        // Trim the string to the length of the column
+        String textToSend = l > columns ? text.substring(0, columns) : text;
+
+        // Set the cursor position to the start of the specified row
+        setCursorPosition(0, row);
+        return addText(textToSend);
+    }
+
+    /**
+     * Add the string to the display at the current position.
+     *
+     * @param text the text
+     * @return this
+     */
+    default L addText(String text) {
+        for (byte character : text.getBytes()) {
+            addText((char)character);
+        }
+        return (L)this;
+    }
+
+    /**
+     * Add a <b>character</b> (e.g. alphanumeric) to the display at the current position.
+     * Typically, this advances the cursor position by 1 in the set direction.
+     *
+     * @param character the text character
+     * @return this
+     */
+    L addText(char character);
+
+    /**
+     * Add a <b>special character</b> to the display at the current position.
+     * Typically, this advances the cursor position by 1 in the set direction.
+     *
+     * @param code the character code
+     * @return this
+     * @see #createChar(int, byte[])
+     */
+    L addText(int code);
+
+    /**
+     * Clear the display
+     *
+     * @return this
+     */
+    L clear();
+
+    /**
+     * Return the cursor to the home position
+     *
+     * @return this
+     */
+    L returnHome();
+
+    /**
+     * Control text entry mode.
+     *
+     * @param increment    The cursor or blinking moves to the right when
+     *                     incremented by 1 and to the left when decremented by 1.
+     * @param shiftDisplay Shifts the entire display either to the right (I/D = 0)
+     *                     or to the left (I/D = 1) when true. The display does not
+     *                     shift if false. If true, it will seem as if the cursor
+     *                     does not move but the display does.
+     * @return This object instance
+     */
+    L entryModeControl(boolean increment, boolean shiftDisplay);
+
+    L autoscrollOn();
+
+    L autoscrollOff();
+
+    boolean isIncrementOn();
+
+    boolean isShiftDisplayOn();
+
+    L displayControl(boolean displayOn, boolean cursorEnabled, boolean blinkEnabled);
+
+    L displayOn();
+
+    L displayOff();
+
+    L cursorOn();
+
+    L cursorOff();
+
+    L blinkOn();
+
+    L blinkOff();
+
+    boolean isCursorEnabled();
+
+    boolean isBlinkEnabled();
+
+    /**
+     * Cursor or display shift shifts the cursor position or display to the right or
+     * left without writing or reading display data. This function is used to
+     * correct or search the display. In a 2-line display, the cursor moves to the
+     * second line when it passes the 40th digit of the first line. Note that the
+     * first and second line displays will shift at the same time. When the
+     * displayed data is shifted repeatedly each line moves only horizontally. The
+     * second line display does not shift into the first line position.
+     *
+     * @param displayShift Shift the display if true, the cursor if false.
+     * @param shiftRight   Shift to the right if true, to the left if false.
+     * @return This object instance
+     */    L cursorOrDisplayShift(boolean displayShift, boolean shiftRight);
+
+    L shiftDisplayRight();
+
+    L shiftDisplayLeft();
+
+    L moveCursorRight();
+
+    L moveCursorLeft();
+
+    /**
+     * Upload a bit-map of a "special character" to the specified location.
+     *
+     * @param location the location/code for this character
+     * @param charMap  the bit-map for the character (one byte per "lines" in the dot matrix)
+     * @return this
+     * @see Characters
+     * @see #addText(int)
+     */
+    L createChar(int location, byte[] charMap);
+
+    class Characters {
+        private static final Map<String, byte[]> CHARACTERS = new HashMap<>();
+
+        static {
+            CHARACTERS.put("0", new byte[]{0xe, 0x1b, 0x1b, 0x1b, 0x1b, 0x1b, 0xe});
+            CHARACTERS.put("1", new byte[]{0x2, 0x6, 0xe, 0x6, 0x6, 0x6, 0x6});
+            CHARACTERS.put("2", new byte[]{0xe, 0x1b, 0x3, 0x6, 0xc, 0x18, 0x1f});
+            CHARACTERS.put("3", new byte[]{0xe, 0x1b, 0x3, 0xe, 0x3, 0x1b, 0xe});
+            CHARACTERS.put("4", new byte[]{0x3, 0x7, 0xf, 0x1b, 0x1f, 0x3, 0x3});
+            CHARACTERS.put("5", new byte[]{0x1f, 0x18, 0x1e, 0x3, 0x3, 0x1b, 0xe});
+            CHARACTERS.put("6", new byte[]{0xe, 0x1b, 0x18, 0x1e, 0x1b, 0x1b, 0xe});
+            CHARACTERS.put("7", new byte[]{0x1f, 0x3, 0x6, 0xc, 0xc, 0xc, 0xc});
+            CHARACTERS.put("8", new byte[]{0xe, 0x1b, 0x1b, 0xe, 0x1b, 0x1b, 0xe});
+            CHARACTERS.put("9", new byte[]{0xe, 0x1b, 0x1b, 0xf, 0x3, 0x1b, 0xe});
+            CHARACTERS.put("10", new byte[]{0x17, 0x15, 0x15, 0x15, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("11", new byte[]{0xa, 0xa, 0xa, 0xa, 0xa, 0x0, 0x1f});
+            CHARACTERS.put("12", new byte[]{0x17, 0x11, 0x17, 0x14, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("13", new byte[]{0x17, 0x11, 0x13, 0x11, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("14", new byte[]{0x15, 0x15, 0x17, 0x11, 0x11, 0x0, 0x1f});
+            CHARACTERS.put("15", new byte[]{0x17, 0x14, 0x17, 0x11, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("16", new byte[]{0x17, 0x14, 0x17, 0x15, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("17", new byte[]{0x17, 0x11, 0x12, 0x12, 0x12, 0x0, 0x1f});
+            CHARACTERS.put("18", new byte[]{0x17, 0x15, 0x17, 0x15, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("19", new byte[]{0x17, 0x15, 0x17, 0x11, 0x17, 0x0, 0x1f});
+            CHARACTERS.put("circle", new byte[]{0x0, 0xe, 0x11, 0x11, 0x11, 0xe, 0x0});
+            CHARACTERS.put("cdot", new byte[]{0x0, 0xe, 0x11, 0x15, 0x11, 0xe, 0x0});
+            CHARACTERS.put("donut", new byte[]{0x0, 0xe, 0x1f, 0x1b, 0x1f, 0xe, 0x0});
+            CHARACTERS.put("ball", new byte[]{0x0, 0xe, 0x1f, 0x1f, 0x1f, 0xe, 0x0});
+            CHARACTERS.put("square", new byte[]{0x0, 0x1f, 0x11, 0x11, 0x11, 0x1f, 0x0});
+            CHARACTERS.put("sdot", new byte[]{0x0, 0x1f, 0x11, 0x15, 0x11, 0x1f, 0x0});
+            CHARACTERS.put("fbox", new byte[]{0x0, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x0});
+            CHARACTERS.put("sbox", new byte[]{0x0, 0x0, 0xe, 0xa, 0xe, 0x0, 0x0});
+            CHARACTERS.put("sfbox", new byte[]{0x0, 0x0, 0xe, 0xe, 0xe, 0x0, 0x0});
+            CHARACTERS.put("bigpointerright", new byte[]{0x8, 0xc, 0xa, 0x9, 0xa, 0xc, 0x8});
+            CHARACTERS.put("bigpointerleft", new byte[]{0x2, 0x6, 0xa, 0x12, 0xa, 0x6, 0x2});
+            CHARACTERS.put("arrowright", new byte[]{0x8, 0xc, 0xa, 0x9, 0xa, 0xc, 0x8});
+            CHARACTERS.put("arrowleft", new byte[]{0x2, 0x6, 0xa, 0x12, 0xa, 0x6, 0x2});
+            CHARACTERS.put("ascprogress1", new byte[]{0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10});
+            CHARACTERS.put("ascprogress2", new byte[]{0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18});
+            CHARACTERS.put("ascprogress3", new byte[]{0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c});
+            CHARACTERS.put("ascprogress4", new byte[]{0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e, 0x1e});
+            CHARACTERS.put("fullprogress", new byte[]{0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f});
+            CHARACTERS.put("descprogress1", new byte[]{1, 1, 1, 1, 1, 1, 1, 1});
+            CHARACTERS.put("descprogress2", new byte[]{3, 3, 3, 3, 3, 3, 3, 3});
+            CHARACTERS.put("descprogress3", new byte[]{7, 7, 7, 7, 7, 7, 7, 7});
+            CHARACTERS.put("descprogress4", new byte[]{15, 15, 15, 15, 15, 15, 15, 15});
+            CHARACTERS.put("ascchart1", new byte[]{31, 0, 0, 0, 0, 0, 0, 0});
+            CHARACTERS.put("ascchart2", new byte[]{31, 31, 0, 0, 0, 0, 0, 0});
+            CHARACTERS.put("ascchart3", new byte[]{31, 31, 31, 0, 0, 0, 0, 0});
+            CHARACTERS.put("ascchart4", new byte[]{31, 31, 31, 31, 0, 0, 0, 0});
+            CHARACTERS.put("ascchart5", new byte[]{31, 31, 31, 31, 31, 0, 0, 0});
+            CHARACTERS.put("ascchart6", new byte[]{31, 31, 31, 31, 31, 31, 0, 0});
+            CHARACTERS.put("ascchart7", new byte[]{31, 31, 31, 31, 31, 31, 31, 0});
+            CHARACTERS.put("descchart1", new byte[]{0, 0, 0, 0, 0, 0, 0, 31});
+            CHARACTERS.put("descchart2", new byte[]{0, 0, 0, 0, 0, 0, 31, 31});
+            CHARACTERS.put("descchart3", new byte[]{0, 0, 0, 0, 0, 31, 31, 31});
+            CHARACTERS.put("descchart4", new byte[]{0, 0, 0, 0, 31, 31, 31, 31});
+            CHARACTERS.put("descchart5", new byte[]{0, 0, 0, 31, 31, 31, 31, 31});
+            CHARACTERS.put("descchart6", new byte[]{0, 0, 31, 31, 31, 31, 31, 31});
+            CHARACTERS.put("descchart7", new byte[]{0, 31, 31, 31, 31, 31, 31, 31});
+            CHARACTERS.put("borderleft1", new byte[]{1, 1, 1, 1, 1, 1, 1, 1});
+            CHARACTERS.put("borderleft2", new byte[]{3, 2, 2, 2, 2, 2, 2, 3});
+            CHARACTERS.put("borderleft3", new byte[]{7, 4, 4, 4, 4, 4, 4, 7});
+            CHARACTERS.put("borderleft4", new byte[]{15, 8, 8, 8, 8, 8, 8, 15});
+            CHARACTERS.put("borderleft5", new byte[]{31, 16, 16, 16, 16, 16, 16, 31});
+            CHARACTERS.put("bordertopbottom5", new byte[]{31, 0, 0, 0, 0, 0, 0, 31});
+            CHARACTERS.put("borderright1", new byte[]{16, 16, 16, 16, 16, 16, 16, 16});
+            CHARACTERS.put("borderright2", new byte[]{24, 8, 8, 8, 8, 8, 8, 24});
+            CHARACTERS.put("borderright3", new byte[]{28, 4, 4, 4, 4, 4, 4, 28});
+            CHARACTERS.put("borderright4", new byte[]{30, 2, 2, 2, 2, 2, 2, 30});
+            CHARACTERS.put("borderright5", new byte[]{31, 1, 1, 1, 1, 1, 1, 31});
+            CHARACTERS.put("box1", new byte[]{3, 3, 3, 0, 0, 0, 0});
+            CHARACTERS.put("box2", new byte[]{24, 24, 24, 0, 0, 0, 0});
+            CHARACTERS.put("box3", new byte[]{27, 27, 27, 0, 0, 0, 0});
+            CHARACTERS.put("box4", new byte[]{0, 0, 0, 0, 3, 3, 3});
+            CHARACTERS.put("box5", new byte[]{3, 3, 3, 0, 3, 3, 3});
+            CHARACTERS.put("box6", new byte[]{24, 24, 24, 0, 3, 3, 3});
+            CHARACTERS.put("box7", new byte[]{27, 27, 27, 0, 3, 3, 3});
+            CHARACTERS.put("box8", new byte[]{0, 0, 0, 0, 24, 24, 24});
+            CHARACTERS.put("box9", new byte[]{3, 3, 3, 0, 24, 24, 24});
+            CHARACTERS.put("box10", new byte[]{24, 24, 24, 0, 24, 24, 24});
+            CHARACTERS.put("box11", new byte[]{27, 27, 27, 0, 24, 24, 24});
+            CHARACTERS.put("box12", new byte[]{0, 0, 0, 0, 27, 27, 27});
+            CHARACTERS.put("box13", new byte[]{3, 3, 3, 0, 27, 27, 27});
+            CHARACTERS.put("box14", new byte[]{24, 24, 24, 0, 27, 27, 27});
+            CHARACTERS.put("box15", new byte[]{27, 27, 27, 0, 27, 27, 27});
+            CHARACTERS.put("euro", new byte[]{3, 4, 30, 8, 30, 8, 7});
+            CHARACTERS.put("cent", new byte[]{0, 0, 14, 17, 16, 21, 14, 8});
+            CHARACTERS.put("speaker", new byte[]{1, 3, 15, 15, 15, 3, 1});
+            CHARACTERS.put("sound", new byte[]{8, 16, 0, 24, 0, 16, 8});
+            CHARACTERS.put("x", new byte[]{0, 27, 14, 4, 14, 27, 0});
+            CHARACTERS.put("target", new byte[]{0, 10, 17, 21, 17, 10, 0});
+            CHARACTERS.put("pointerright", new byte[]{0, 8, 12, 14, 12, 8, 0});
+            CHARACTERS.put("pointerup", new byte[]{0, 0, 4, 14, 31, 0, 0});
+            CHARACTERS.put("pointerleft", new byte[]{0, 2, 6, 14, 6, 2, 0});
+            CHARACTERS.put("pointerdown", new byte[]{0, 0, 31, 14, 4, 0, 0});
+            CHARACTERS.put("arrowne", new byte[]{0, 15, 3, 5, 9, 16, 0});
+            CHARACTERS.put("arrownw", new byte[]{0, 30, 24, 20, 18, 1, 0});
+            CHARACTERS.put("arrowsw", new byte[]{0, 1, 18, 20, 24, 30, 0});
+            CHARACTERS.put("arrowse", new byte[]{0, 16, 9, 5, 3, 15, 0});
+            CHARACTERS.put("dice1", new byte[]{0, 0, 0, 4, 0, 0, 0});
+            CHARACTERS.put("dice2", new byte[]{0, 16, 0, 0, 0, 1, 0});
+            CHARACTERS.put("dice3", new byte[]{0, 16, 0, 4, 0, 1, 0});
+            CHARACTERS.put("dice4", new byte[]{0, 17, 0, 0, 0, 17, 0});
+            CHARACTERS.put("dice5", new byte[]{0, 17, 0, 4, 0, 17, 0});
+            CHARACTERS.put("dice6", new byte[]{0, 17, 0, 17, 0, 17, 0});
+            CHARACTERS.put("bell", new byte[]{4, 14, 14, 14, 31, 0, 4});
+            CHARACTERS.put("smile", new byte[]{0, 10, 0, 17, 14, 0, 0});
+            CHARACTERS.put("note", new byte[]{2, 3, 2, 14, 30, 12, 0});
+            CHARACTERS.put("clock", new byte[]{0, 14, 21, 23, 17, 14, 0});
+            CHARACTERS.put("heart", new byte[]{0, 10, 31, 31, 31, 14, 4, 0});
+            CHARACTERS.put("duck", new byte[]{0, 12, 29, 15, 15, 6, 0});
+            CHARACTERS.put("check", new byte[]{0, 1, 3, 22, 28, 8, 0});
+            CHARACTERS.put("retarrow", new byte[]{1, 1, 5, 9, 31, 8, 4});
+            CHARACTERS.put("runninga", new byte[]{6, 6, 5, 14, 20, 4, 10, 17});
+            CHARACTERS.put("runningb", new byte[]{6, 6, 4, 14, 14, 4, 10, 10});
+            CHARACTERS.put("space_invader", new byte[]{0x00, 0x0e, 0x15, 0x1f, 0x0a, 0x04, 0x0a, 0x11});
+            CHARACTERS.put("smilie", new byte[]{0x00, 0x00, 0x0a, 0x00, 0x00, 0x11, 0x0e, 0x00});
+            CHARACTERS.put("frownie", new byte[]{0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x0e, 0x11});
+        }
+
+        /**
+         * Get the specs for the specified character
+         *
+         * @param name the name of the character
+         * @return the uploadable byte-spec
+         */
+        public static byte[] get(String name) {
+            return CHARACTERS.get(name);
+        }
+
+        /**
+         * @return the names of the defined characters
+         */
+        public static Collection<String> getCharacters() {
+            return CHARACTERS.keySet();
+        }
+    }
+}

--- a/diozero-core/src/test/java/com/diozero/devices/LcdInterfaceTest.java
+++ b/diozero-core/src/test/java/com/diozero/devices/LcdInterfaceTest.java
@@ -1,0 +1,108 @@
+package com.diozero.devices;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for basic text-handling in LCD interfaces.
+ */
+class LcdInterfaceTest {
+    LcdInterface<?> mockInterface = mock(LcdInterface.class);
+
+    List<Character> textOutputPerRow = new ArrayList<>();
+    List<String> textOutput = new ArrayList<>();
+
+    String hexChars = "0123456789ABCDEF";
+
+    @BeforeEach
+    void setUp() {
+        textOutputPerRow.clear();
+        textOutput.clear();
+
+        when(mockInterface.addText(anyChar())).thenAnswer((Answer<LcdInterface<?>>) invoked -> {
+            textOutputPerRow.add(invoked.getArgument(0));
+            return mockInterface;
+        });
+        // the assumption is if the cursor position is being set, move the previous data off as a single "line" of
+        // text
+        when(mockInterface.setCursorPosition(anyInt(), anyInt())).thenAnswer((Answer<LcdInterface<?>>) invoked -> {
+            // if there's no text, do not capture
+            if (! textOutputPerRow.isEmpty()) {
+                StringBuilder sb = new StringBuilder();
+                textOutputPerRow.forEach(sb::append);
+                textOutputPerRow.clear();
+                textOutput.add(sb.toString());
+            }
+            return mockInterface;
+        });
+        // cheating...
+        when(mockInterface.returnHome())
+                .thenAnswer((Answer<LcdInterface<?>>) invoked -> mockInterface.setCursorPosition(0,0));
+        when(mockInterface.setText(anyInt(), anyString())).thenCallRealMethod();
+        when(mockInterface.addText(anyString())).thenCallRealMethod();
+        when(mockInterface.displayText(anyString())).thenCallRealMethod();
+        when(mockInterface.getColumnCount()).thenReturn(16);
+        when(mockInterface.getRowCount()).thenReturn(2);
+    }
+
+    @Test
+    public void basicSingleCharacterOutput() {
+        for (byte character : hexChars.getBytes()) {
+            mockInterface.addText((char)character);
+        }
+        mockInterface.returnHome(); // trigger capture
+        assertEquals(hexChars, textOutput.get(0));
+    }
+
+    @Test
+    public void basicTwoLineOutput() {
+        String secondLine = "Hello, World!!!!";
+        mockInterface.setText(0, hexChars);
+        mockInterface.setText(1, secondLine);
+        mockInterface.returnHome(); // trigger capture
+
+        assertEquals(hexChars, textOutput.get(0));
+        assertEquals(secondLine, textOutput.get(1));
+    }
+
+    @Test
+    public void truncateString() {
+        mockInterface.setText(0, hexChars + " This is the end.");
+        mockInterface.returnHome(); // trigger capture
+
+        assertEquals(hexChars, textOutput.get(0));
+    }
+
+    @Test
+    public void displayTextWithNewlines() {
+        mockInterface.displayText("Hello,\nWorld!");
+        mockInterface.returnHome(); // trigger capture
+
+        assertTrue(textOutput.get(0).startsWith("Hello,"));
+        assertEquals(16, textOutput.get(0).length());
+        assertTrue(textOutput.get(1).startsWith("World!"));
+        assertEquals(16, textOutput.get(0).length());
+    }
+
+    @Test
+    public void trimDisplayTextWithTooManyNewLines() {
+        mockInterface.displayText("Hello,\nWorld!\nThe Larch");
+        mockInterface.returnHome(); // trigger capture
+
+        assertEquals(2, textOutput.size(), "Did not trim lines");
+        assertTrue(textOutput.get(0).startsWith("Hello,"));
+        assertEquals(16, textOutput.get(0).length());
+        assertTrue(textOutput.get(1).startsWith("World!"));
+        assertEquals(16, textOutput.get(0).length());
+    }
+}

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/I2CLcdSampleApp20x4.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/I2CLcdSampleApp20x4.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     I2CLcdSampleApp20x4.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,7 @@ import org.tinylog.Logger;
 import com.diozero.api.I2CConstants;
 import com.diozero.api.RuntimeIOException;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.LcdConnection;
+import com.diozero.devices.LcdConnection;
 import com.diozero.util.SleepUtil;
 
 /**
@@ -59,7 +59,7 @@ import com.diozero.util.SleepUtil;
 public class I2CLcdSampleApp20x4 {
 	// Main program block
 	public static void main(String[] args) {
-		int device_address = HD44780Lcd.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
+		int device_address = LcdConnection.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
 		if (args.length > 0) {
 			device_address = Integer.decode(args[0]).intValue();
 		}
@@ -67,9 +67,9 @@ public class I2CLcdSampleApp20x4 {
 		if (args.length > 1) {
 			controller = Integer.parseInt(args[1]);
 		}
-		
+
 		// Initialise display
-		try (LcdConnection lcd_connection = new HD44780Lcd.PCF8574LcdConnection(controller, device_address);
+		try (LcdConnection lcd_connection = new LcdConnection.PCF8574LcdConnection(controller, device_address);
 				HD44780Lcd lcd = new HD44780Lcd(lcd_connection, 20, 4)) {
 			byte[] space_invader = new byte[] { 0x00, 0x0e, 0x15, 0x1f, 0x0a, 0x04, 0x0a, 0x11 };
 			byte[] smilie = new byte[] { 0x00, 0x00, 0x0a, 0x00, 0x00, 0x11, 0x0e, 0x00 };
@@ -78,7 +78,7 @@ public class I2CLcdSampleApp20x4 {
 			lcd.createChar(1, smilie);
 			lcd.createChar(2, frownie);
 			lcd.clear();
-			
+
 			for (int i=0; i<2; i++) {
 				lcd.setCursorPosition(0, i*2);
 				lcd.addText('H');
@@ -105,7 +105,7 @@ public class I2CLcdSampleApp20x4 {
 			}
 			SleepUtil.sleepSeconds(5);
 			lcd.clear();
-			
+
 			for (int i=0; i<2; i++) {
 				// Send some text
 				lcd.setText(0, "Hello -");
@@ -113,10 +113,10 @@ public class I2CLcdSampleApp20x4 {
 				lcd.setText(2, "Hello -");
 				lcd.setText(3, "World! " + i);
 				SleepUtil.sleepSeconds(1);
-				
+
 				lcd.clear();
 				SleepUtil.sleepSeconds(1);
-			  
+
 				// Send some more text
 				lcd.setText(0, ">            diozero");
 				lcd.setText(1, ">            I2C LCD");
@@ -124,15 +124,15 @@ public class I2CLcdSampleApp20x4 {
 				lcd.setText(3, ">            I2C LCD");
 				SleepUtil.sleepSeconds(1);
 			}
-			
+
 			SleepUtil.sleepSeconds(1);
 			lcd.clear();
-			
+
 			for (byte b : "Hello Matt!".getBytes()) {
 				lcd.addText(b);
 				SleepUtil.sleepSeconds(.2);
 			}
-			
+
 			SleepUtil.sleepSeconds(1);
 			lcd.clear();
 
@@ -176,7 +176,7 @@ public class I2CLcdSampleApp20x4 {
 			}
 			Logger.info("Sleeping for 10 seconds...");
 			SleepUtil.sleepSeconds(10);
-			
+
 			lcd.clear();
 		} catch (RuntimeIOException e) {
 			Logger.error(e, "Error: {}", e);

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/I2CLcdSampleAppInteractive.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/I2CLcdSampleAppInteractive.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     I2CLcdSampleAppInteractive.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,7 +39,7 @@ import com.diozero.api.I2CConstants;
 import com.diozero.api.RuntimeIOException;
 import com.diozero.api.function.Action;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.LcdConnection;
+import com.diozero.devices.LcdConnection;
 
 /**
  * I2C LCD sample interactive application. To run:
@@ -60,7 +60,7 @@ import com.diozero.devices.HD44780Lcd.LcdConnection;
  */
 public class I2CLcdSampleAppInteractive implements AutoCloseable {
 	public static void main(String[] args) {
-		int device_address = HD44780Lcd.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
+		int device_address = LcdConnection.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
 		if (args.length > 0) {
 			device_address = Integer.decode(args[0]).intValue();
 		}
@@ -132,7 +132,7 @@ public class I2CLcdSampleAppInteractive implements AutoCloseable {
 
 		int columns = Integer.parseInt(resolution[0]);
 		int rows = Integer.parseInt(resolution[1]);
-		try (LcdConnection lcd_connection = new HD44780Lcd.PCF8574LcdConnection(controller, deviceAddress)) {
+		try (LcdConnection lcd_connection = new LcdConnection.PCF8574LcdConnection(controller, deviceAddress)) {
 			lcd = new HD44780Lcd(lcd_connection, columns, rows);
 
 			running.set(true);

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdGame.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdGame.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     LcdGame.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,10 +41,10 @@ import org.tinylog.Logger;
 import com.diozero.api.I2CConstants;
 import com.diozero.devices.Button;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.PCF8574LcdConnection;
+import com.diozero.devices.LcdConnection;
+import com.diozero.devices.LcdConnection.PCF8574LcdConnection;
 import com.diozero.util.RangeUtil;
 import com.diozero.util.SleepUtil;
-
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -80,7 +80,7 @@ public class LcdGame implements AutoCloseable, Runnable {
 	private int i2cController;
 	@Option(names = { "-a",
 			"--i2c-device-address" }, required = false, description = "I2C device address", defaultValue = ""
-					+ HD44780Lcd.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS)
+					+ PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS)
 	private int i2cDeviceAddress;
 	@Option(names = { "-l", "--left-gpio" }, required = true, description = "GPIO for the move left button")
 	private int leftGpio;
@@ -89,7 +89,7 @@ public class LcdGame implements AutoCloseable, Runnable {
 	@Option(names = { "-o", "--ok-gpio" }, required = true, description = "GPIO for the ok button")
 	private int okGpio;
 
-	private HD44780Lcd.LcdConnection lcdConnection;
+	private LcdConnection lcdConnection;
 	private HD44780Lcd lcd;
 	private Button leftButton;
 	private Button rightButton;

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2Base.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2Base.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     LcdSampleApp16x2Base.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,6 +34,7 @@ package com.diozero.sampleapps.lcd;
 import org.tinylog.Logger;
 
 import com.diozero.devices.HD44780Lcd;
+import com.diozero.devices.LcdInterface;
 import com.diozero.util.SleepUtil;
 
 public class LcdSampleApp16x2Base {
@@ -48,9 +49,9 @@ public class LcdSampleApp16x2Base {
 		*/
 
 		// 0, 14, 21, 31, 10, 4, 10, 17
-		byte[] space_invader = HD44780Lcd.Characters.get("space_invader");
-		byte[] smilie = HD44780Lcd.Characters.get("smilie");
-		byte[] frownie = HD44780Lcd.Characters.get("frownie");
+		byte[] space_invader = LcdInterface.Characters.get("space_invader");
+		byte[] smilie = LcdInterface.Characters.get("smilie");
+		byte[] frownie = LcdInterface.Characters.get("frownie");
 		lcd.createChar(0, space_invader);
 		lcd.createChar(1, smilie);
 		lcd.createChar(2, frownie);
@@ -83,8 +84,8 @@ public class LcdSampleApp16x2Base {
 		lcd.clear();
 
 		Logger.info("Running");
-		lcd.createChar(3, HD44780Lcd.Characters.get("runninga"));
-		lcd.createChar(4, HD44780Lcd.Characters.get("runningb"));
+		lcd.createChar(3, LcdInterface.Characters.get("runninga"));
+		lcd.createChar(4, LcdInterface.Characters.get("runningb"));
 		lcd.clear();
 		lcd.displayControl(true, false, false);
 		for (int i = 0; i < 40; i++) {

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2Gpio.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2Gpio.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     LcdSampleApp16x2Gpio.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,8 +35,8 @@ import org.tinylog.Logger;
 
 import com.diozero.api.RuntimeIOException;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.GpioLcdConnection;
-import com.diozero.devices.HD44780Lcd.LcdConnection;
+import com.diozero.devices.LcdConnection.GpioLcdConnection;
+import com.diozero.devices.LcdConnection;
 import com.diozero.util.Diozero;
 
 /**

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2PCF8574.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2PCF8574.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     LcdSampleApp16x2PCF8574.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,8 +35,8 @@ import org.tinylog.Logger;
 
 import com.diozero.api.RuntimeIOException;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.LcdConnection;
-import com.diozero.devices.HD44780Lcd.PCF8574LcdConnection;
+import com.diozero.devices.LcdConnection;
+import com.diozero.devices.LcdConnection.PCF8574LcdConnection;
 import com.diozero.util.Diozero;
 
 /**
@@ -51,7 +51,7 @@ import com.diozero.util.Diozero;
 public class LcdSampleApp16x2PCF8574 {
 	// Main program block
 	public static void main(String[] args) {
-		int device_address = HD44780Lcd.PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
+		int device_address = PCF8574LcdConnection.DEFAULT_DEVICE_ADDRESS;
 		if (args.length > 0) {
 			device_address = Integer.decode(args[0]).intValue();
 		}
@@ -65,7 +65,7 @@ public class LcdSampleApp16x2PCF8574 {
 
 		// Initialise display
 		try (LcdConnection lcd_connection = new PCF8574LcdConnection(controller, device_address);
-				HD44780Lcd lcd = new HD44780Lcd(lcd_connection, columns, rows)) {
+			 HD44780Lcd lcd = new HD44780Lcd(lcd_connection, columns, rows)) {
 			LcdSampleApp16x2Base.test(lcd);
 		} catch (RuntimeIOException e) {
 			Logger.error(e, "Error: {}", e);

--- a/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2PiFaceCad.java
+++ b/diozero-sampleapps/src/main/java/com/diozero/sampleapps/lcd/LcdSampleApp16x2PiFaceCad.java
@@ -5,7 +5,7 @@ package com.diozero.sampleapps.lcd;
  * Organisation: diozero
  * Project:      diozero - Sample applications
  * Filename:     LcdSampleApp16x2PiFaceCad.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.sampleapps.lcd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,8 +36,8 @@ import org.tinylog.Logger;
 import com.diozero.api.RuntimeIOException;
 import com.diozero.api.SpiConstants;
 import com.diozero.devices.HD44780Lcd;
-import com.diozero.devices.HD44780Lcd.LcdConnection;
-import com.diozero.devices.HD44780Lcd.PiFaceCadLcdConnection;
+import com.diozero.devices.LcdConnection;
+import com.diozero.devices.LcdConnection.PiFaceCadLcdConnection;
 
 /**
  * LCD sample application connected via PiFace Control and Display (SPI MCP23S17). To run:
@@ -63,13 +63,13 @@ public class LcdSampleApp16x2PiFaceCad {
 		if (args.length > 0) {
 			controller = Integer.parseInt(args[0]);
 		}
-		
+
 		int columns = 16;
 		int rows = 2;
-		
+
 		// Initialise display
 		try (LcdConnection lcd_connection = new PiFaceCadLcdConnection(controller);
-				HD44780Lcd lcd = new HD44780Lcd(lcd_connection, columns, rows)) {
+			 HD44780Lcd lcd = new HD44780Lcd(lcd_connection, columns, rows)) {
 			LcdSampleApp16x2Base.test(lcd);
 		} catch (RuntimeIOException e) {
 			Logger.error(e, "Error: {}", e);


### PR DESCRIPTION
This enables additional displays to use the same text-checking and handling, not to mention any commonality in the actual interface to the device.

Also adds a new method `displayText` that allows for newlines and padding (clearing) the display.