### PR TITLE
Soft pwm error

### DIFF
--- a/diozero-core/src/main/java/com/diozero/internal/SoftwarePwmOutputDevice.java
+++ b/diozero-core/src/main/java/com/diozero/internal/SoftwarePwmOutputDevice.java
@@ -1,5 +1,36 @@
 package com.diozero.internal;
 
+/*
+ * #%L
+ * Organisation: diozero
+ * Project:      diozero - Core
+ * Filename:     SoftwarePwmOutputDevice.java
+ *
+ * This file is part of the diozero project. More information about this project
+ * can be found at https://www.diozero.com/.
+ * %%
+ * Copyright (C) 2016 - 2022 diozero
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
The previous PR was only tested with a _servo_ device, which only reacts to a single pulse to activate, versus something like an LED which requires the _constant_ inputs to keep the value.

On a hunch, replaced the lock-based sleep with the newer busy-wait and the previously observed jitter on the servo is almost entirely eliminated. Also tested with an LED, which also now does not exhibit a previously observed flickering (I thought I had lousy LED's :shrug:).

Bumped the log message to WARN so it's a bit more obvious that what is being used may not be what the user wanted. :smiley: