### PR TITLE
Consolidated checking for already opened devices.

### DIFF
--- a/diozero-core/src/main/java/com/diozero/internal/spi/AnalogInputDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/AnalogInputDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     AnalogInputDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,34 +31,19 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.DeviceMode;
 import com.diozero.api.InvalidModeException;
-import com.diozero.api.NoSuchDeviceException;
 import com.diozero.api.PinInfo;
 import com.diozero.api.RuntimeIOException;
 
 public interface AnalogInputDeviceFactoryInterface extends DeviceFactoryInterface {
 	default AnalogInputDeviceInterface provisionAnalogInputDevice(PinInfo pinInfo) throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
-
-		if (!pinInfo.isSupported(DeviceMode.ANALOG_INPUT)) {
-			throw new InvalidModeException("Invalid mode (analog input) for pin " + pinInfo);
-		}
-
-		String key = createPinKey(pinInfo);
-
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		AnalogInputDeviceInterface device = createAnalogInputDevice(key, pinInfo);
-		deviceOpened(device);
-
-		return device;
+		return registerPinDevice(pinInfo, (k) -> {
+			if (!pinInfo.isSupported(DeviceMode.ANALOG_INPUT)) {
+				throw new InvalidModeException("Invalid mode (analog input) for pin " + pinInfo);
+			}
+			return createAnalogInputDevice(k, pinInfo);
+		});
 	}
 
 	AnalogInputDeviceInterface createAnalogInputDevice(String key, PinInfo pinInfo);

--- a/diozero-core/src/main/java/com/diozero/internal/spi/AnalogOutputDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/AnalogOutputDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     AnalogOutputDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,35 +31,21 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.DeviceMode;
 import com.diozero.api.InvalidModeException;
-import com.diozero.api.NoSuchDeviceException;
 import com.diozero.api.PinInfo;
 import com.diozero.api.RuntimeIOException;
 
 public interface AnalogOutputDeviceFactoryInterface extends DeviceFactoryInterface {
 	default AnalogOutputDeviceInterface provisionAnalogOutputDevice(PinInfo pinInfo, float initialValue)
 			throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
-		
-		if (!pinInfo.isSupported(DeviceMode.ANALOG_OUTPUT)) {
-			throw new InvalidModeException("Invalid mode (analog output) for pin " + pinInfo);
-		}
 
-		String key = createPinKey(pinInfo);
-
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		AnalogOutputDeviceInterface device = createAnalogOutputDevice(key, pinInfo, initialValue);
-		deviceOpened(device);
-
-		return device;
+		return registerPinDevice(pinInfo, (k) -> {
+			if (!pinInfo.isSupported(DeviceMode.ANALOG_OUTPUT)) {
+				throw new InvalidModeException("Invalid mode (analog output) for pin " + pinInfo);
+			}
+			return createAnalogOutputDevice(k, pinInfo, initialValue);
+		});
 	}
 
 	AnalogOutputDeviceInterface createAnalogOutputDevice(String key, PinInfo pinInfo, float initialValue);

--- a/diozero-core/src/main/java/com/diozero/internal/spi/GpioDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/GpioDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     GpioDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,92 +31,59 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
-import com.diozero.api.DeviceMode;
-import com.diozero.api.GpioEventTrigger;
-import com.diozero.api.GpioPullUpDown;
-import com.diozero.api.InvalidModeException;
-import com.diozero.api.NoSuchDeviceException;
-import com.diozero.api.PinInfo;
-import com.diozero.api.RuntimeIOException;
+import com.diozero.api.*;
 
 public interface GpioDeviceFactoryInterface extends DeviceFactoryInterface {
-	default GpioDigitalInputDeviceInterface provisionDigitalInputDevice(PinInfo pinInfo, GpioPullUpDown pud,
-			GpioEventTrigger trigger) throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
-		
-		if (!pinInfo.isSupported(DeviceMode.DIGITAL_INPUT)) {
-			throw new InvalidModeException("Invalid mode (digital input) for pin " + pinInfo);
-		}
+    default GpioDigitalInputDeviceInterface provisionDigitalInputDevice(
+            PinInfo pinInfo,
+            GpioPullUpDown pud,
+            GpioEventTrigger trigger) throws RuntimeIOException {
 
-		String key = createPinKey(pinInfo);
+        return registerPinDevice(pinInfo, (k) -> {
+            if (!pinInfo.isSupported(DeviceMode.DIGITAL_INPUT)) {
+                throw new InvalidModeException("Invalid mode (digital input) for pin " + pinInfo);
+            }
+            return createDigitalInputDevice(k, pinInfo, pud, trigger);
+        });
+    }
 
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
+    default GpioDigitalOutputDeviceInterface provisionDigitalOutputDevice(PinInfo pinInfo, boolean initialValue)
+            throws RuntimeIOException {
+        if (pinInfo == null) {
+            throw new NoSuchDeviceException("No such device - pinInfo was null");
+        }
 
-		GpioDigitalInputDeviceInterface device = createDigitalInputDevice(key, pinInfo, pud, trigger);
-		deviceOpened(device);
+        return registerPinDevice(pinInfo, (k) -> {
+            if (!pinInfo.isSupported(DeviceMode.DIGITAL_OUTPUT)) {
+                throw new InvalidModeException("Invalid mode (digital output) for pin " + pinInfo);
+            }
+            return createDigitalOutputDevice(k, pinInfo, initialValue);
+        });
+    }
 
-		return device;
-	}
+    default GpioDigitalInputOutputDeviceInterface provisionDigitalInputOutputDevice(PinInfo pinInfo, DeviceMode mode)
+            throws RuntimeIOException {
+        if (pinInfo == null) {
+            throw new NoSuchDeviceException("No such device - pinInfo was null");
+        }
 
-	default GpioDigitalOutputDeviceInterface provisionDigitalOutputDevice(PinInfo pinInfo, boolean initialValue)
-			throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
-		
-		if (!pinInfo.isSupported(DeviceMode.DIGITAL_OUTPUT)) {
-			throw new InvalidModeException("Invalid mode (digital output) for pin " + pinInfo);
-		}
+        return registerPinDevice(pinInfo, (k) -> {
+            if (!pinInfo.getModes().containsAll(PinInfo.DIGITAL_IN_OUT)) {
+                throw new InvalidModeException("Invalid mode (digital input/output) for pin " + pinInfo);
+            }
+            if (mode != DeviceMode.DIGITAL_INPUT && mode != DeviceMode.DIGITAL_OUTPUT) {
+                throw new InvalidModeException("Invalid mode, must be DIGITAL_INPUT or DIGITAL_OUTPUT");
+            }
 
-		String key = createPinKey(pinInfo);
+            return createDigitalInputOutputDevice(k, pinInfo, mode);
+        });
+    }
 
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
 
-		GpioDigitalOutputDeviceInterface device = createDigitalOutputDevice(key, pinInfo, initialValue);
-		deviceOpened(device);
+    GpioDigitalInputDeviceInterface createDigitalInputDevice(String key, PinInfo pinInfo, GpioPullUpDown pud,
+                                                             GpioEventTrigger trigger);
 
-		return device;
-	}
+    GpioDigitalOutputDeviceInterface createDigitalOutputDevice(String key, PinInfo pinInfo, boolean initialValue);
 
-	default GpioDigitalInputOutputDeviceInterface provisionDigitalInputOutputDevice(PinInfo pinInfo, DeviceMode mode)
-			throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
-		
-		if (!pinInfo.getModes().containsAll(PinInfo.DIGITAL_IN_OUT)) {
-			throw new InvalidModeException("Invalid mode (digital input/output) for pin " + pinInfo);
-		}
-		if (mode != DeviceMode.DIGITAL_INPUT && mode != DeviceMode.DIGITAL_OUTPUT) {
-			throw new InvalidModeException("Invalid mode, must be DIGITAL_INPUT or DIGITAL_OUTPUT");
-		}
-
-		String key = createPinKey(pinInfo);
-
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		GpioDigitalInputOutputDeviceInterface device = createDigitalInputOutputDevice(key, pinInfo, mode);
-		deviceOpened(device);
-
-		return device;
-	}
-
-	GpioDigitalInputDeviceInterface createDigitalInputDevice(String key, PinInfo pinInfo, GpioPullUpDown pud,
-			GpioEventTrigger trigger);
-
-	GpioDigitalOutputDeviceInterface createDigitalOutputDevice(String key, PinInfo pinInfo, boolean initialValue);
-
-	GpioDigitalInputOutputDeviceInterface createDigitalInputOutputDevice(String key, PinInfo pinInfo, DeviceMode mode);
+    GpioDigitalInputOutputDeviceInterface createDigitalInputOutputDevice(String key, PinInfo pinInfo, DeviceMode mode);
 }

--- a/diozero-core/src/main/java/com/diozero/internal/spi/I2CDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/I2CDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     I2CDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,6 @@ import java.util.List;
 
 import org.tinylog.Logger;
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.I2CConstants;
 import com.diozero.api.RuntimeIOException;
 
@@ -45,17 +44,9 @@ public interface I2CDeviceFactoryInterface extends DeviceFactoryInterface {
 
 	default InternalI2CDeviceInterface provisionI2CDevice(int controller, int address,
 			I2CConstants.AddressSize addressSize) throws RuntimeIOException {
-		String key = createI2CKey(controller, address);
 
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		InternalI2CDeviceInterface device = createI2CDevice(key, controller, address, addressSize);
-		deviceOpened(device);
-
-		return device;
+		return registerDevice(() -> createI2CKey(controller, address),
+							  (k) -> createI2CDevice(k, controller, address, addressSize));
 	}
 
 	InternalI2CDeviceInterface createI2CDevice(String key, int controller, int address,

--- a/diozero-core/src/main/java/com/diozero/internal/spi/PwmOutputDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/PwmOutputDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     PwmOutputDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,41 +31,24 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
-import com.diozero.api.DeviceMode;
-import com.diozero.api.InvalidModeException;
-import com.diozero.api.NoSuchDeviceException;
-import com.diozero.api.PinInfo;
-import com.diozero.api.RuntimeIOException;
+import com.diozero.api.*;
 
 public interface PwmOutputDeviceFactoryInterface extends DeviceFactoryInterface {
-	int getBoardPwmFrequency();
+    int getBoardPwmFrequency();
 
-	void setBoardPwmFrequency(int pwmFrequency);
+    void setBoardPwmFrequency(int pwmFrequency);
 
-	default InternalPwmOutputDeviceInterface provisionPwmOutputDevice(PinInfo pinInfo, int pwmFrequency,
-			float initialValue) throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
+    default InternalPwmOutputDeviceInterface provisionPwmOutputDevice(PinInfo pinInfo, int pwmFrequency,
+                                                                      float initialValue) throws RuntimeIOException {
+        return registerPinDevice(pinInfo, (k) -> {
+            if (!pinInfo.isSupported(DeviceMode.PWM_OUTPUT) && !pinInfo.isSupported(DeviceMode.DIGITAL_OUTPUT)) {
+                throw new InvalidModeException("Invalid mode (PWM output) for GPIO " + pinInfo);
+            }
 
-		if (!pinInfo.isSupported(DeviceMode.PWM_OUTPUT) && !pinInfo.isSupported(DeviceMode.DIGITAL_OUTPUT)) {
-			throw new InvalidModeException("Invalid mode (PWM output) for GPIO " + pinInfo);
-		}
+            return createPwmOutputDevice(k, pinInfo, pwmFrequency, initialValue);
+        });
+    }
 
-		String key = createPinKey(pinInfo);
-
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		InternalPwmOutputDeviceInterface device = createPwmOutputDevice(key, pinInfo, pwmFrequency, initialValue);
-		deviceOpened(device);
-
-		return device;
-	}
-
-	InternalPwmOutputDeviceInterface createPwmOutputDevice(String key, PinInfo pinInfo, int pwmFrequency,
-			float initialValue);
+    InternalPwmOutputDeviceInterface createPwmOutputDevice(String key, PinInfo pinInfo, int pwmFrequency,
+                                                           float initialValue);
 }

--- a/diozero-core/src/main/java/com/diozero/internal/spi/SerialDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/SerialDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     SerialDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,7 +31,6 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.RuntimeIOException;
 import com.diozero.api.SerialDevice;
 
@@ -56,18 +55,10 @@ public interface SerialDeviceFactoryInterface extends DeviceFactoryInterface {
 	default InternalSerialDeviceInterface provisionSerialDevice(String deviceFilename, int baud,
 			SerialDevice.DataBits dataBits, SerialDevice.StopBits stopBits, SerialDevice.Parity parity,
 			boolean readBlocking, int minReadChars, int readTimeoutMillis) throws RuntimeIOException {
-		String key = createSerialKey(deviceFilename);
 
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		InternalSerialDeviceInterface device = createSerialDevice(key, deviceFilename, baud, dataBits, stopBits, parity,
-				readBlocking, minReadChars, readTimeoutMillis);
-		deviceOpened(device);
-
-		return device;
+		return registerDevice(()->createSerialKey(deviceFilename),
+							  (k)-> createSerialDevice(k, deviceFilename, baud, dataBits, stopBits, parity,
+													   readBlocking, minReadChars, readTimeoutMillis));
 	}
 
 	InternalSerialDeviceInterface createSerialDevice(String key, String deviceFilename, int baud,

--- a/diozero-core/src/main/java/com/diozero/internal/spi/ServoDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/ServoDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     ServoDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,10 +31,8 @@ package com.diozero.internal.spi;
  * #L%
  */
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.DeviceMode;
 import com.diozero.api.InvalidModeException;
-import com.diozero.api.NoSuchDeviceException;
 import com.diozero.api.PinInfo;
 import com.diozero.api.RuntimeIOException;
 
@@ -45,26 +43,13 @@ public interface ServoDeviceFactoryInterface extends DeviceFactoryInterface {
 
 	default InternalServoDeviceInterface provisionServoDevice(PinInfo pinInfo, int frequencyHz, int minPulseWidthUs,
 			int maxPulseWidthUs, int initialPulseWidthUs) throws RuntimeIOException {
-		if (pinInfo == null) {
-			throw new NoSuchDeviceException("No such device - pinInfo was null");
-		}
 
-		if (!pinInfo.isSupported(DeviceMode.SERVO)) {
-			throw new InvalidModeException("Invalid mode (Servo) for GPIO " + pinInfo);
-		}
-
-		String key = createPinKey(pinInfo);
-
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-
-		InternalServoDeviceInterface device = createServoDevice(key, pinInfo, frequencyHz, minPulseWidthUs,
-				maxPulseWidthUs, initialPulseWidthUs);
-		deviceOpened(device);
-
-		return device;
+		return registerPinDevice(pinInfo, (k) -> {
+			if (!pinInfo.isSupported(DeviceMode.SERVO)) {
+				throw new InvalidModeException("Invalid mode (Servo) for GPIO " + pinInfo);
+			}
+			return createServoDevice(k, pinInfo, frequencyHz, minPulseWidthUs, maxPulseWidthUs, initialPulseWidthUs);
+		});
 	}
 
 	InternalServoDeviceInterface createServoDevice(String key, PinInfo pinInfo, int frequencyHz, int minPulseWidthUs,

--- a/diozero-core/src/main/java/com/diozero/internal/spi/SpiDeviceFactoryInterface.java
+++ b/diozero-core/src/main/java/com/diozero/internal/spi/SpiDeviceFactoryInterface.java
@@ -5,7 +5,7 @@ package com.diozero.internal.spi;
  * Organisation: diozero
  * Project:      diozero - Core
  * Filename:     SpiDeviceFactoryInterface.java
- * 
+ *
  * This file is part of the diozero project. More information about this project
  * can be found at https://www.diozero.com/.
  * %%
@@ -17,10 +17,10 @@ package com.diozero.internal.spi;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,10 +35,10 @@ package com.diozero.internal.spi;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.tinylog.Logger;
 
-import com.diozero.api.DeviceAlreadyOpenedException;
 import com.diozero.api.RuntimeIOException;
 import com.diozero.api.SpiClockMode;
 
@@ -47,37 +47,28 @@ public interface SpiDeviceFactoryInterface extends DeviceFactoryInterface {
 	 * Many distributions have a maximum SPI transfer of 4096 bytes. This can be changed in /boot/cmdline.txt by appending
 	 *  spidev.bufsiz=32768
  	 */
-	static final int DEFAULT_SPI_BUFFER_SIZE = 4096;
-	static final String SPI_PREFIX = "-SPI-";
-	
+	int DEFAULT_SPI_BUFFER_SIZE = 4096;
+	String SPI_PREFIX = "-SPI-";
+
 	default InternalSpiDeviceInterface provisionSpiDevice(int controller, int chipSelect,
 			int frequency, SpiClockMode spiClockMode, boolean lsbFirst) throws RuntimeIOException {
-		String key = createSpiKey(controller, chipSelect);
-		
-		// Check if this pin is already provisioned
-		if (isDeviceOpened(key)) {
-			throw new DeviceAlreadyOpenedException("Device " + key + " is already in use");
-		}
-		
-		InternalSpiDeviceInterface device = createSpiDevice(key, controller, chipSelect, frequency, spiClockMode, lsbFirst);
-		deviceOpened(device);
-		
-		return device;
+
+		return registerDevice(()->createSpiKey(controller, chipSelect),
+					   (k) ->createSpiDevice(k, controller, chipSelect, frequency, spiClockMode, lsbFirst));
 	}
 
 	InternalSpiDeviceInterface createSpiDevice(String key, int controller, int chipSelect, int frequency,
 			SpiClockMode spiClockMode, boolean lsbFirst) throws RuntimeIOException;
 
 	default int getSpiBufferSize() {
-		try {
-			return Files.lines(Paths.get("/sys/module/spidev/parameters/bufsiz")).mapToInt(Integer::parseInt).findFirst()
-					.orElse(DEFAULT_SPI_BUFFER_SIZE);
+		try(Stream<String> stream = Files.lines(Paths.get("/sys/module/spidev/parameters/bufsiz"))) {
+			return stream.mapToInt(Integer::parseInt).findFirst().orElse(DEFAULT_SPI_BUFFER_SIZE);
 		} catch (IOException e) {
 			Logger.warn("Unable to read kernel SPI buffer size, using default: {}", e);
 			return DEFAULT_SPI_BUFFER_SIZE;
 		}
 	}
-	
+
 	static String createSpiKey(String keyPrefix, int controller, int chipSelect) {
 		return keyPrefix + SPI_PREFIX + controller + "-" + chipSelect;
 	}


### PR DESCRIPTION
Fixes #132

Basically replaces some boilerplate using functional call-backs for specifics around "actual" device creation.