### PR TITLE
Fix #112

### DIFF
--- a/diozero-core/src/main/java/com/diozero/devices/MFRC522.java
+++ b/diozero-core/src/main/java/com/diozero/devices/MFRC522.java
@@ -1937,6 +1937,8 @@ public class MFRC522 implements DeviceInterface {
 			return false;
 		}
 
+		block0_buffer = Arrays.copyOf(block0_buffer, 16); //Remove the CRC_A which is also returned by mifareRead
+
 		// Write new UID to the data we just read, and calculate BCC byte
 		byte bcc = 0;
 		for (int i = 0; i < uid.getSize(); i++) {


### PR DESCRIPTION
The issue was caused by not omitting the CRC_A returned by the `mifareRead` function.
**I suggest checking other usages of the method for the same issue**

After compiling this patch, I can confirm that `mifareSetUid` works correctly.