### PR TITLE
Upgrade of Google Protobuf executable

### DIFF
--- a/diozero-remote-common/pom.xml
+++ b/diozero-remote-common/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-		<protoc.version>3.17.2</protoc.version>
+		<protoc.version>3.22.2</protoc.version>
 		<motd-os-maven-plugin.version>1.7.0</motd-os-maven-plugin.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 	</properties>


### PR DESCRIPTION
I wasn't able to build project and run tests on OSX with M1 processor without this upgrade. There were no executables compiled for Apple silicon for the old version.

Looking at the protobuf release notes - no breaking changes found.
There were mostly bug fixes, additional features, performance improvements and Java 7 support abandonment (diozero is using Java 11+).