### PR TITLE
Make MCP23017 stable and avoid blinking on reboot

### DIFF
--- a/diozero-core/src/main/java/com/diozero/devices/mcp23xxx/MCP23xxx.java
+++ b/diozero-core/src/main/java/com/diozero/devices/mcp23xxx/MCP23xxx.java
@@ -191,11 +191,10 @@ public abstract class MCP23xxx extends AbstractDeviceFactory implements GpioDevi
 		}
 
 		for (int port = 0; port < numPorts; port++) {
-			// Read currently set GPIOs directions
-			directions[port] = new MutableByte(readByte(getIODirReg(port)));
-			// Read current state of pull-up resistors
-			pullUps[port] = new MutableByte(readByte(getGPPullUpReg(port)));
+			byte currentStates = readByte(getGPIOReg(port));
 
+			// Default all GPIOs to output
+			writeByte(getIODirReg(port), directions[port].getValue());
 			// Default to normal input polarity - IPOLA/IPOLB
 			writeByte(getIPolReg(port), (byte) 0);
 			// Disable interrupt-on-change for all GPIOs
@@ -204,6 +203,10 @@ public abstract class MCP23xxx extends AbstractDeviceFactory implements GpioDevi
 			writeByte(getDefValReg(port), defaultValues[port].getValue());
 			// Disable interrupt comparison control
 			writeByte(getIntConReg(port), interruptCompareFlags[port].getValue());
+			// Disable pull-up resistors
+			writeByte(getGPPullUpReg(port), pullUps[port].getValue());
+			// Set pin states to the values read earlier
+			writeByte(getGPIOReg(port), currentStates);
 		}
 
 		// Finally enable interrupt listeners

--- a/diozero-remote-common/pom.xml
+++ b/diozero-remote-common/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-		<protoc.version>3.17.2</protoc.version>
+		<protoc.version>3.22.2</protoc.version>
 		<motd-os-maven-plugin.version>1.7.0</motd-os-maven-plugin.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 	</properties>


### PR DESCRIPTION
Solves the problem with randomly breaking I2C bus when rebooting device (caused by my previous PR and [described here](https://github.com/mattjlewis/diozero/pull/126#issuecomment-1455219926)).
At the same time, this change still allows to keep MCP23xxx pins up and avoid side effects on reboot like blinking lights.

I've been running this for two weeks on 5 devices without any problems. I've tried to reboot the devices multiple times to make sure it is not causing I2C bus stuck, like it was previously.
I am sure this version is better than the one I've created in [the previous PR](https://github.com/mattjlewis/diozero/pull/126) and I hope it will be good enough in general :) .