### PR TITLE
Updates protobuf/grpc depencencies.

### DIFF
--- a/diozero-bom/pom.xml
+++ b/diozero-bom/pom.xml
@@ -86,9 +86,9 @@
 		<hipparchus.version>3.1</hipparchus.version>
 		<eclipse-paho-client-mqttv3.version>1.2.5</eclipse-paho-client-mqttv3.version>
 		<google-gson.version>2.11.0</google-gson.version>
-		<google-protobuf-java.version>4.28.2</google-protobuf-java.version>
-		<netty.version>4.1.114.Final</netty.version>
-		<grpc.version>1.68.0</grpc.version>
+		<google-protobuf-java.version>4.29.3</google-protobuf-java.version>
+		<netty.version>4.1.115.Final</netty.version>
+		<grpc.version>1.69.0</grpc.version>
 		<junit.version>5.11.2</junit.version>
 		<mockito.version>5.14.1</mockito.version>
 	</properties>


### PR DESCRIPTION
There is a transitive dependency of the `grpc.version` that had a high-severity security warning, so a little bump and all's good.